### PR TITLE
Allow derive_traits() to use var_info columns by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glydet (development version)
 
+## Minor improvements and bug fixes
+
+* `derive_traits()` can now use columns in `var_info` as meta-properties without specifying `mp_cols`. Built-in meta-properties keep precedence by default; use `mp_cols` when columns need renaming or explicit overrides (#10).
+
 # glydet 0.10.4
 
 ## Minor improvements and bug fixes

--- a/R/derive-traits.R
+++ b/R/derive-traits.R
@@ -24,9 +24,11 @@
 #' @param mp_cols A character vector of column names in the `var_info` tibble to use as meta-properties.
 #'   If names are provided, they will be used as names of the meta-properties,
 #'   otherwise the column names will be used.
-#'   Meta-properties specified in `mp_cols` will overwrite those introduced by `mp_fns` with the same names,
-#'   including the built-in meta-properties.
-#'   Default is `NULL`, which means no columns are used as meta-properties.
+#'   When `mp_cols` is specified, the selected columns overwrite meta-properties introduced by `mp_fns`
+#'   with the same names, including built-in meta-properties.
+#'   Default is `NULL`, which means all columns in `var_info` are available as meta-properties by their
+#'   existing names. In this default mode, meta-properties introduced by `mp_fns` take precedence over
+#'   `var_info` columns with the same names.
 #'
 #' @returns
 #' A new [glyexp::experiment()] object for derived traits.
@@ -295,7 +297,10 @@ derive_traits_ <- function(tbl, data_type, trait_fns = NULL, mp_fns = NULL) {
 #' @noRd
 .get_mps <- function(exp, mp_fns, mp_cols) {
   if (is.null(mp_cols)) {
-    mp_cols <- character()
+    mp_tbl1 <- get_meta_properties(exp$var_info[["glycan_structure"]], mp_fns)
+    mp_tbl2 <- exp$var_info |>
+      dplyr::select(-dplyr::any_of(colnames(mp_tbl1)))
+    return(dplyr::bind_cols(mp_tbl1, mp_tbl2))
   }
   mp_tbl1 <- exp$var_info |>
     dplyr::select(dplyr::all_of(mp_cols))
@@ -380,7 +385,7 @@ derive_traits_ <- function(tbl, data_type, trait_fns = NULL, mp_fns = NULL) {
       "Trait functions must use defined meta-properties.",
       "x" = "Unknown meta-properties: {.field {objs_not_found}}",
       "i" = "Available meta-properties: {.field {colnames(mp_tbl)}}",
-      "i" = "Did you forget to define custom meta-properties in {.arg mp_fns} or {.arg mp_cols}?"
+      "i" = "Did you forget to add matching {.field var_info} columns, define custom meta-properties in {.arg mp_fns}, or use {.arg mp_cols} to rename columns?"
     ), call = NULL)
   }
 

--- a/R/quantify-motifs.R
+++ b/R/quantify-motifs.R
@@ -92,7 +92,7 @@
 #' trait_fns <- list(Lx = wsum(nLx), SLx = wsum(nSLx))
 #'
 #' # Calculate the traits
-#' derive_traits(exp_with_mps, trait_fns = trait_fns, mp_cols = c("nLx", "nSLx"))
+#' derive_traits(exp_with_mps, trait_fns = trait_fns)
 #' ```
 #'
 #' The code snippet above is equivalent to:

--- a/man/derive_traits.Rd
+++ b/man/derive_traits.Rd
@@ -28,9 +28,11 @@ Default is \code{NULL}, which means all meta-properties in \code{\link[=all_mp_f
 \item{mp_cols}{A character vector of column names in the \code{var_info} tibble to use as meta-properties.
 If names are provided, they will be used as names of the meta-properties,
 otherwise the column names will be used.
-Meta-properties specified in \code{mp_cols} will overwrite those introduced by \code{mp_fns} with the same names,
-including the built-in meta-properties.
-Default is \code{NULL}, which means no columns are used as meta-properties.}
+When \code{mp_cols} is specified, the selected columns overwrite meta-properties introduced by \code{mp_fns}
+with the same names, including built-in meta-properties.
+Default is \code{NULL}, which means all columns in \code{var_info} are available as meta-properties by their
+existing names. In this default mode, meta-properties introduced by \code{mp_fns} take precedence over
+\code{var_info} columns with the same names.}
 }
 \value{
 A new \code{\link[glyexp:experiment]{glyexp::experiment()}} object for derived traits.

--- a/man/quantify_motifs.Rd
+++ b/man/quantify_motifs.Rd
@@ -165,7 +165,7 @@ exp_with_mps <- glymotif::add_motifs_int(exp, motifs)
 trait_fns <- list(Lx = wsum(nLx), SLx = wsum(nSLx))
 
 # Calculate the traits
-derive_traits(exp_with_mps, trait_fns = trait_fns, mp_cols = c("nLx", "nSLx"))
+derive_traits(exp_with_mps, trait_fns = trait_fns)
 }\if{html}{\out{</div>}}
 
 The code snippet above is equivalent to:

--- a/tests/testthat/test-derive-traits.R
+++ b/tests/testthat/test-derive-traits.R
@@ -231,6 +231,75 @@ test_that("derive_traits works with custom meta-property columns", {
   expect_true("explanation" %in% colnames(trait_exp$var_info))
 })
 
+test_that("derive_traits uses var_info columns as meta-properties by default", {
+  var_info <- tibble::tibble(
+    variable = c("V1", "V2", "V3"),
+    glycan_structure = glyparse::parse_iupac_condensed(c(
+      "Neu5Ac(a2-?)Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-",
+      "Neu5Ac(a2-?)Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-",
+      "Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+    )),
+    nE = c(0L, 1L, 0L),
+    nL = c(1L, 0L, 0L),
+    glycan_composition = glyrepr::as_glycan_composition(glycan_structure)
+  )
+  sample_info <- tibble::tibble(sample = c("S1", "S2", "S3"))
+  expr_mat <- matrix(
+    c(1, 0, 1,
+      1, 1, 1,
+      1, 1, 0),
+    nrow = 3, ncol = 3, byrow = TRUE
+  )
+  rownames(expr_mat) <- c("V1", "V2", "V3")
+  colnames(expr_mat) <- c("S1", "S2", "S3")
+  exp <- glyexp::experiment(expr_mat, sample_info, var_info, exp_type = "glycomics", glycan_type = "N")
+
+  trait_fns <- list(
+    EG = wmean(nE / nG),
+    LG = wmean(nL / nG)
+  )
+  trait_exp <- derive_traits(exp, trait_fns)
+
+  expected_expr_mat <- matrix(
+    c(1/3, 0.5, 0.5,
+      1/3, 0, 0.5),
+    nrow = 2, ncol = 3, byrow = TRUE
+  )
+  rownames(expected_expr_mat) <- c("EG", "LG")
+  colnames(expected_expr_mat) <- c("S1", "S2", "S3")
+  expect_equal(trait_exp$expr_mat, expected_expr_mat)
+})
+
+test_that("derive_traits gives built-in meta-properties precedence over var_info columns by default", {
+  var_info <- tibble::tibble(
+    variable = c("V1", "V2", "V3"),
+    glycan_structure = glyparse::parse_iupac_condensed(c(
+      "Neu5Ac(a2-?)Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-",
+      "Neu5Ac(a2-?)Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-",
+      "Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+    )),
+    nS = c(0L, 0L, 0L),
+    glycan_composition = glyrepr::as_glycan_composition(glycan_structure)
+  )
+  sample_info <- tibble::tibble(sample = c("S1", "S2", "S3"))
+  expr_mat <- matrix(
+    c(1, 0, 1,
+      1, 1, 1,
+      1, 1, 0),
+    nrow = 3, ncol = 3, byrow = TRUE
+  )
+  rownames(expr_mat) <- c("V1", "V2", "V3")
+  colnames(expr_mat) <- c("S1", "S2", "S3")
+  exp <- glyexp::experiment(expr_mat, sample_info, var_info, exp_type = "glycomics", glycan_type = "N")
+
+  trait_exp <- derive_traits(exp, list(TS = prop(nS > 0)))
+
+  expected_expr_mat <- matrix(c(2/3, 0.5, 1), nrow = 1)
+  rownames(expected_expr_mat) <- "TS"
+  colnames(expected_expr_mat) <- c("S1", "S2", "S3")
+  expect_equal(trait_exp$expr_mat, expected_expr_mat)
+})
+
 test_that("derive_traits works with custom meta-property columns that overwrite existing meta-properties", {
   # Construct a test experiment
   var_info <- tibble::tibble(

--- a/vignettes/custom-traits.Rmd
+++ b/vignettes/custom-traits.Rmd
@@ -529,8 +529,7 @@ by introducing more sophisticated and linkage-awared meta-properties.
 
 The first method is handy if all information you need is already encoded in glycan structures.
 However, there are situations that you need to rely on other meta-data.
-In this case, you can use columns in the variable information tibble as meta-properties directly,
-by specifying the `mp_cols` parameter.
+In this case, you can use columns in the variable information tibble as meta-properties directly.
 
 For example, let's use the sialic acid linkage type example above.
 You might have used special derivatization methods to differentiate the two linkage types.
@@ -567,11 +566,26 @@ sia_traits <- list(
 )
 ```
 
-And use `mp_cols` to tell `derive_traits()` to use these columns as meta-properties:
+If the column names match the meta-property names used in the trait definitions,
+`derive_traits()` can use them directly:
+
+```{r}
+exp3 <- exp2 |>
+  rename_var(nE = n_a26_sia, nL = n_a23_sia)
+
+derive_traits(exp3, trait_fns = sia_traits)
+```
+
+If you want to use different column names in `var_info`,
+use `mp_cols` to map those columns to the meta-property names in the trait definitions:
 
 ```{r}
 derive_traits(exp2, trait_fns = sia_traits, mp_cols = c(nL = "n_a23_sia", nE = "n_a26_sia"))
 ```
+
+When `mp_cols` is omitted, built-in meta-properties take precedence over `var_info` columns
+with the same names. Use `mp_cols` only when you intentionally want selected columns to
+rename or overwrite meta-properties.
 
 ## Using `make_trait()`
 

--- a/vignettes/quantify-motifs.Rmd
+++ b/vignettes/quantify-motifs.Rmd
@@ -160,7 +160,7 @@ exp_with_mps <- glymotif::add_motifs_int(exp, motifs)
 trait_fns <- list(Lxa = wsum(nLxa), SLxa = wsum(nSLxa))
 
 # Calculate the traits
-derive_traits(exp_with_mps, trait_fns = trait_fns, mp_cols = c("nLxa", "nSLxa"))
+derive_traits(exp_with_mps, trait_fns = trait_fns)
 ```
 
 This code snippet is functionally equivalent to:


### PR DESCRIPTION
## Summary
- Let `derive_traits()` treat `var_info` columns as meta-properties when `mp_cols` is omitted.
- Keep built-in and `mp_fns` meta-properties ahead of same-named `var_info` columns by default.
- Preserve `mp_cols` for explicit renaming and override cases.
- Update the derived-traits and motif-quantification docs/examples to match the new default behavior.
- Add tests covering implicit column use, built-in precedence, and the existing explicit override path.

## Testing
- `devtools::document()`
- `devtools::test(filter = "derive-traits")`
- `devtools::test(filter = "quantify-motifs")`
- `devtools::test()`

Closes #10 