### PR TITLE
Add provider-configurable AI support to make_trait() and explain_trait()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Minor improvements and bug fixes
 
-* `make_trait()` now supports configurable `ellmer` providers, including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints, with `glydet.ai_*` package options for session defaults.
+* `make_trait()` and AI-enabled `explain_trait()` now support configurable `ellmer` providers, including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints, with `glydet.ai_*` package options for session defaults.
 * `derive_traits()` can now use columns in `var_info` as meta-properties without specifying `mp_cols`. Built-in meta-properties keep precedence by default; use `mp_cols` when columns need renaming or explicit overrides (#10).
 
 # glydet 0.10.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Minor improvements and bug fixes
 
+* `make_trait()` now supports configurable `ellmer` providers, including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints, with `glydet.ai_*` package options for session defaults.
 * `derive_traits()` can now use columns in `var_info` as meta-properties without specifying `mp_cols`. Built-in meta-properties keep precedence by default; use `mp_cols` when columns need renaming or explicit overrides (#10).
 
 # glydet 0.10.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Minor improvements and bug fixes
 
-* `make_trait()` and AI-enabled `explain_trait()` now support configurable `ellmer` providers, including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints, with `glydet.ai_*` package options for session defaults.
+* `make_trait()` and AI-enabled `explain_trait()` now support configurable `ellmer` providers, including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints, with `glydet.ai_*` package options for session defaults (#14).
 * `derive_traits()` can now use columns in `var_info` as meta-properties without specifying `mp_cols`. Built-in meta-properties keep precedence by default; use `mp_cols` when columns need renaming or explicit overrides (#10).
 
 # glydet 0.10.4

--- a/R/explain-trait.R
+++ b/R/explain-trait.R
@@ -17,7 +17,8 @@
 #'   "(type) description". Only used when `use_ai = TRUE`.
 #' @param provider AI provider passed to `ellmer` when `use_ai = TRUE`.
 #'   One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
-#'   "openai_compatible". Defaults to
+#'   "openai_compatible". "google_gemini" is accepted as an alias for
+#'   "gemini". Defaults to
 #'   `getOption("glydet.ai_provider", "deepseek")`.
 #' @param model Model to use when `use_ai = TRUE`. Defaults to
 #'   `getOption("glydet.ai_model")`, or "deepseek-chat" for DeepSeek and the

--- a/R/explain-trait.R
+++ b/R/explain-trait.R
@@ -10,12 +10,23 @@
 #'   Whether to use a Large Language Model (LLM) to explain the trait. Default is FALSE.
 #'   To use this feature, you need to install the `ellmer` package.
 #'   DeepSeek is used by default for backward compatibility. Other `ellmer`
-#'   providers can be selected with the `glydet.ai_provider`,
-#'   `glydet.ai_model`, `glydet.ai_api_key`, and `glydet.ai_base_url`
-#'   package options.
+#'   providers can be selected with `provider`, `model`, and provider-specific
+#'   API key configuration.
 #' @param custom_mp A named character vector of custom meta-properties.
 #'   The names are the meta-property names, and the values are in the format
 #'   "(type) description". Only used when `use_ai = TRUE`.
+#' @param provider AI provider passed to `ellmer` when `use_ai = TRUE`.
+#'   One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
+#'   "openai_compatible". Defaults to
+#'   `getOption("glydet.ai_provider", "deepseek")`.
+#' @param model Model to use when `use_ai = TRUE`. Defaults to
+#'   `getOption("glydet.ai_model")`, or "deepseek-chat" for DeepSeek and the
+#'   provider default for other providers.
+#' @param api_key API key for the selected provider. If `NULL`, the provider
+#'   specific environment variable is used. Defaults to
+#'   `getOption("glydet.ai_api_key")`.
+#' @param base_url Optional base URL for custom or OpenAI-compatible endpoints.
+#'   Defaults to `getOption("glydet.ai_base_url")`.
 #'
 #' @returns A character string containing a concise English explanation of the trait.
 #'
@@ -37,12 +48,28 @@
 #' explain_trait(wsum(nS, within = (Tp == "complex")))
 #'
 #' @export
-explain_trait <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   UseMethod("explain_trait")
 }
 
 #' @export
-explain_trait.default <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait.default <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   cli::cli_abort(c(
     "Object must be a glydet trait function.",
     "x" = "Got an object of class {.cls {class(trait_fn)}}.",
@@ -51,45 +78,120 @@ explain_trait.default <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
 }
 
 #' @export
-explain_trait.glydet_prop <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait.glydet_prop <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   if (use_ai) {
-    .explain_with_ai(trait_fn, custom_mp)
+    .explain_with_ai(
+      trait_fn,
+      custom_mp,
+      provider = provider,
+      model = model,
+      api_key = api_key,
+      base_url = base_url
+    )
   } else {
     .explain_prop(trait_fn)
   }
 }
 
 #' @export
-explain_trait.glydet_ratio <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait.glydet_ratio <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   if (use_ai) {
-    .explain_with_ai(trait_fn, custom_mp)
+    .explain_with_ai(
+      trait_fn,
+      custom_mp,
+      provider = provider,
+      model = model,
+      api_key = api_key,
+      base_url = base_url
+    )
   } else {
     .explain_ratio(trait_fn)
   }
 }
 
 #' @export
-explain_trait.glydet_wmean <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait.glydet_wmean <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   if (use_ai) {
-    .explain_with_ai(trait_fn, custom_mp)
+    .explain_with_ai(
+      trait_fn,
+      custom_mp,
+      provider = provider,
+      model = model,
+      api_key = api_key,
+      base_url = base_url
+    )
   } else {
     .explain_wmean(trait_fn)
   }
 }
 
 #' @export
-explain_trait.glydet_total <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait.glydet_total <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   if (use_ai) {
-    .explain_with_ai(trait_fn, custom_mp)
+    .explain_with_ai(
+      trait_fn,
+      custom_mp,
+      provider = provider,
+      model = model,
+      api_key = api_key,
+      base_url = base_url
+    )
   } else {
     .explain_total(trait_fn)
   }
 }
 
 #' @export
-explain_trait.glydet_wsum <- function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+explain_trait.glydet_wsum <- function(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   if (use_ai) {
-    .explain_with_ai(trait_fn, custom_mp)
+    .explain_with_ai(
+      trait_fn,
+      custom_mp,
+      provider = provider,
+      model = model,
+      api_key = api_key,
+      base_url = base_url
+    )
   } else {
     .explain_wsum(trait_fn)
   }
@@ -577,10 +679,24 @@ explain_trait.glydet_wsum <- function(trait_fn, use_ai = FALSE, custom_mp = NULL
   paste(prompt, example_prompt, sep = "\n")
 }
 
-.explain_with_ai <- function(trait_fn, custom_mp = NULL) {
+.explain_with_ai <- function(
+  trait_fn,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   trait_str <- rlang::expr_text(trait_fn)
   str_type <- stringr::str_extract(trait_str, "prop|ratio|wmean|total|wsum")
   system_prompt <- .explain_sys_prompt(str_type, custom_mp)
   user_prompt <- paste0("INPUT: ", trait_str, "\nOUTPUT: ")
-  .ask_ai(system_prompt, user_prompt)
+  .ask_ai(
+    system_prompt,
+    user_prompt,
+    api_key = api_key,
+    model = model,
+    provider = provider,
+    base_url = base_url
+  )
 }

--- a/R/explain-trait.R
+++ b/R/explain-trait.R
@@ -9,9 +9,10 @@
 #' @param use_ai `r lifecycle::badge("experimental")`
 #'   Whether to use a Large Language Model (LLM) to explain the trait. Default is FALSE.
 #'   To use this feature, you need to install the `ellmer` package.
-#'   You also need to provide an API key for the DeepSeek chat model.
-#'   Please set the environment variable `DEEPSEEK_API_KEY` to your API key.
-#'   You can obtain an API key from https://platform.deepseek.com.
+#'   DeepSeek is used by default for backward compatibility. Other `ellmer`
+#'   providers can be selected with the `glydet.ai_provider`,
+#'   `glydet.ai_model`, `glydet.ai_api_key`, and `glydet.ai_base_url`
+#'   package options.
 #' @param custom_mp A named character vector of custom meta-properties.
 #'   The names are the meta-property names, and the values are in the format
 #'   "(type) description". Only used when `use_ai = TRUE`.

--- a/R/make-trait.R
+++ b/R/make-trait.R
@@ -28,7 +28,8 @@
 #'   This is useful for inspecting how LLMs generate trait functions.
 #' @param provider AI provider passed to `ellmer`. One of "deepseek",
 #'   "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
-#'   Defaults to `getOption("glydet.ai_provider", "deepseek")`.
+#'   "google_gemini" is accepted as an alias for "gemini". Defaults to
+#'   `getOption("glydet.ai_provider", "deepseek")`.
 #' @param model Model to use. Defaults to `getOption("glydet.ai_model")`,
 #'   or "deepseek-chat" for DeepSeek and the provider default for other providers.
 #' @param api_key API key for the selected provider. If `NULL`, the provider
@@ -64,6 +65,9 @@ make_trait <- function(
   checkmate::assert_character(custom_mp, names = "named", null.ok = TRUE)
   checkmate::assert_count(max_retries)
   provider <- .normalize_ai_provider(provider)
+  model <- .normalize_optional_ai_string(model)
+  api_key <- .normalize_optional_ai_string(api_key)
+  base_url <- .normalize_optional_ai_string(base_url)
   checkmate::assert_string(model, null.ok = TRUE)
   checkmate::assert_string(api_key, null.ok = TRUE)
   checkmate::assert_string(base_url, null.ok = TRUE)

--- a/R/make-trait.R
+++ b/R/make-trait.R
@@ -193,16 +193,16 @@ make_trait <- function(
   base_url = getOption("glydet.ai_base_url", NULL)
 ) {
   # Get AI explanation of the generated trait
-  old_options <- options(
-    glydet.ai_provider = provider,
-    glydet.ai_model = model,
-    glydet.ai_api_key = api_key,
-    glydet.ai_base_url = base_url
-  )
-  on.exit(options(old_options), add = TRUE)
-
   explanation <- tryCatch(
-    explain_trait(trait_fn, use_ai = TRUE, custom_mp = custom_mp),
+    explain_trait(
+      trait_fn,
+      use_ai = TRUE,
+      custom_mp = custom_mp,
+      api_key = api_key,
+      model = model,
+      provider = provider,
+      base_url = base_url
+    ),
     error = function(e) NULL
   )
 

--- a/R/make-trait.R
+++ b/R/make-trait.R
@@ -8,9 +8,9 @@
 #' Try to read the descriptions of built-in traits to get ideas.
 #' Currently, only `prop()`, `ratio()`, and `wmean()` are supported.
 #' To use this feature, you need to install the `ellmer` package.
-#' You also need to provide an API key for the DeepSeek chat model.
-#' Please set the environment variable `DEEPSEEK_API_KEY` to your API key using `Sys.setenv()`.
-#' You can obtain an API key from https://platform.deepseek.com.
+#' DeepSeek is used by default for backward compatibility. Other `ellmer`
+#' providers can be selected with `provider`, `model`, and provider-specific
+#' API key configuration.
 #'
 #' @param description A description of the trait in natural language.
 #' @param custom_mp A named character vector of custom meta-properties.
@@ -26,6 +26,16 @@
 #'   formula's explanation doesn't match the original description. Default is 2.
 #' @param verbose Whether to print verbose output. Default is FALSE.
 #'   This is useful for inspecting how LLMs generate trait functions.
+#' @param provider AI provider passed to `ellmer`. One of "deepseek",
+#'   "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
+#'   Defaults to `getOption("glydet.ai_provider", "deepseek")`.
+#' @param model Model to use. Defaults to `getOption("glydet.ai_model")`,
+#'   or "deepseek-chat" for DeepSeek and the provider default for other providers.
+#' @param api_key API key for the selected provider. If `NULL`, the provider
+#'   specific environment variable is used. Defaults to
+#'   `getOption("glydet.ai_api_key")`.
+#' @param base_url Optional base URL for custom or OpenAI-compatible endpoints.
+#'   Defaults to `getOption("glydet.ai_base_url")`.
 #'
 #' @returns A derived trait function.
 #'
@@ -40,21 +50,36 @@
 #' # derive_traits(exp, trait_fns = my_traits)
 #'
 #' @export
-make_trait <- function(description, custom_mp = NULL, max_retries = 2, verbose = FALSE) {
+make_trait <- function(
+  description,
+  custom_mp = NULL,
+  max_retries = 2,
+  verbose = FALSE,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   checkmate::assert_string(description)
   checkmate::assert_character(custom_mp, names = "named", null.ok = TRUE)
   checkmate::assert_count(max_retries)
+  provider <- .normalize_ai_provider(provider)
+  checkmate::assert_string(model, null.ok = TRUE)
+  checkmate::assert_string(api_key, null.ok = TRUE)
+  checkmate::assert_string(base_url, null.ok = TRUE)
   description <- stringr::str_trim(description)
   rlang::check_installed("ellmer")
 
-  api_key <- .get_api_key()
+  model <- .resolve_ai_model(provider, model)
+  api_key <- .get_api_key(provider = provider, api_key = api_key)
   system_prompt <- .make_trait_sys_prompt(description, custom_mp)
 
-  chat <- ellmer::chat_deepseek(
+  chat <- .create_ai_chat(
     system_prompt = system_prompt,
-    model = "deepseek-chat",
-    echo = "none",
-    credentials = function() api_key
+    api_key = api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
   )
 
   # Initial prompt
@@ -92,7 +117,15 @@ make_trait <- function(description, custom_mp = NULL, max_retries = 2, verbose =
 
     # Valid formula, now do reflection check
     trait_fn <- result$trait_fn
-    reflection_result <- .check_trait_consistency(description, trait_fn, custom_mp)
+    reflection_result <- .check_trait_consistency(
+      description,
+      trait_fn,
+      custom_mp,
+      api_key = api_key,
+      model = model,
+      provider = provider,
+      base_url = base_url
+    )
 
     if (reflection_result$consistent) {
       return(trait_fn)
@@ -150,8 +183,24 @@ make_trait <- function(description, custom_mp = NULL, max_retries = 2, verbose =
   )
 }
 
-.check_trait_consistency <- function(description, trait_fn, custom_mp = NULL) {
+.check_trait_consistency <- function(
+  description,
+  trait_fn,
+  custom_mp = NULL,
+  api_key = getOption("glydet.ai_api_key", NULL),
+  model = getOption("glydet.ai_model", NULL),
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   # Get AI explanation of the generated trait
+  old_options <- options(
+    glydet.ai_provider = provider,
+    glydet.ai_model = model,
+    glydet.ai_api_key = api_key,
+    glydet.ai_base_url = base_url
+  )
+  on.exit(options(old_options), add = TRUE)
+
   explanation <- tryCatch(
     explain_trait(trait_fn, use_ai = TRUE, custom_mp = custom_mp),
     error = function(e) NULL
@@ -163,12 +212,26 @@ make_trait <- function(description, custom_mp = NULL, max_retries = 2, verbose =
   }
 
   # Ask AI to judge if the explanation matches the description
-  is_consistent <- .ask_ai_consistency(description, explanation)
+  is_consistent <- .ask_ai_consistency(
+    description,
+    explanation,
+    api_key = api_key,
+    model = model,
+    provider = provider,
+    base_url = base_url
+  )
 
   list(consistent = is_consistent, explanation = explanation)
 }
 
-.ask_ai_consistency <- function(description, explanation) {
+.ask_ai_consistency <- function(
+  description,
+  explanation,
+  api_key = getOption("glydet.ai_api_key", NULL),
+  model = getOption("glydet.ai_model", NULL),
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   system_prompt <- paste(
     "You are a professional glycobiologist.",
     "Your task is to judge if two statements about glycan traits are semantically equivalent.",
@@ -182,7 +245,14 @@ make_trait <- function(description, custom_mp = NULL, max_retries = 2, verbose =
     "Are these two statements semantically equivalent? Answer YES or NO only."
   )
 
-  response <- .ask_ai(system_prompt, user_prompt)
+  response <- .ask_ai(
+    system_prompt,
+    user_prompt,
+    api_key = api_key,
+    model = model,
+    provider = provider,
+    base_url = base_url
+  )
   stringr::str_detect(toupper(response), "YES")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,6 +53,18 @@
   provider
 }
 
+#' Normalize optional AI string arguments
+#'
+#' @param value Optional string value.
+#' @returns `NULL` for missing or empty values, otherwise the original value.
+#' @noRd
+.normalize_optional_ai_string <- function(value) {
+  if (is.null(value) || identical(value, "")) {
+    return(NULL)
+  }
+  value
+}
+
 #' Human-readable AI provider label
 #'
 #' @param provider Provider name.
@@ -98,6 +110,7 @@
   model = getOption("glydet.ai_model", NULL)
 ) {
   provider <- .normalize_ai_provider(provider)
+  model <- .normalize_optional_ai_string(model)
   if (!is.null(model)) {
     return(model)
   }
@@ -117,6 +130,7 @@
   provider = getOption("glydet.ai_provider", "deepseek"),
   api_key = getOption("glydet.ai_api_key", NULL)
 ) {
+  api_key <- .normalize_optional_ai_string(api_key)
   if (!is.null(api_key) && nzchar(api_key)) {
     return(api_key)
   }
@@ -125,11 +139,17 @@
   api_key <- Sys.getenv(envvar)
   if (api_key == "") {
     label <- .ai_provider_label(provider)
-    cli::cli_abort(c(
+    bullets <- c(
       "API key for {label} chat model is not set.",
-      "i" = "Please set the environment variable `{envvar}` to your API key, or pass `api_key` directly.",
-      "i" = "For OpenAI-compatible endpoints, set `OPENAI_API_KEY` and pass `base_url`."
-    ))
+      "i" = "Please set the environment variable `{envvar}` to your API key, or pass `api_key` directly."
+    )
+    if (identical(provider, "openai_compatible")) {
+      bullets <- c(
+        bullets,
+        "i" = "For OpenAI-compatible endpoints, also pass `base_url`."
+      )
+    }
+    cli::cli_abort(bullets)
   }
   api_key
 }
@@ -153,6 +173,7 @@
   rlang::check_installed("ellmer")
   provider <- .normalize_ai_provider(provider)
   model <- .resolve_ai_model(provider, model)
+  base_url <- .normalize_optional_ai_string(base_url)
 
   args <- list(
     system_prompt = system_prompt,

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,26 +22,197 @@
   }
 }
 
-.get_api_key <- function() {
-  api_key <- Sys.getenv("DEEPSEEK_API_KEY")
+#' Supported AI provider names
+#'
+#' @returns Character vector of provider choices accepted by glydet.
+#' @noRd
+.ai_provider_choices <- function() {
+  c(
+    "deepseek",
+    "openai",
+    "anthropic",
+    "gemini",
+    "google_gemini",
+    "openrouter",
+    "openai_compatible"
+  )
+}
+
+#' Normalize AI provider aliases
+#'
+#' @param provider Provider name or supported alias.
+#' @returns Canonical provider name.
+#' @noRd
+.normalize_ai_provider <- function(
+  provider = getOption("glydet.ai_provider", "deepseek")
+) {
+  provider <- rlang::arg_match(provider, .ai_provider_choices())
+  if (identical(provider, "google_gemini")) {
+    return("gemini")
+  }
+  provider
+}
+
+#' Human-readable AI provider label
+#'
+#' @param provider Provider name.
+#' @returns Provider label for messages.
+#' @noRd
+.ai_provider_label <- function(provider) {
+  switch(
+    .normalize_ai_provider(provider),
+    deepseek = "DeepSeek",
+    openai = "OpenAI",
+    anthropic = "Anthropic",
+    gemini = "Google Gemini",
+    openrouter = "OpenRouter",
+    openai_compatible = "OpenAI-compatible"
+  )
+}
+
+#' Environment variable for an AI provider API key
+#'
+#' @param provider Provider name.
+#' @returns Environment variable name.
+#' @noRd
+.ai_provider_envvar <- function(provider) {
+  switch(
+    .normalize_ai_provider(provider),
+    deepseek = "DEEPSEEK_API_KEY",
+    openai = "OPENAI_API_KEY",
+    anthropic = "ANTHROPIC_API_KEY",
+    gemini = "GEMINI_API_KEY",
+    openrouter = "OPENROUTER_API_KEY",
+    openai_compatible = "OPENAI_API_KEY"
+  )
+}
+
+#' Resolve the default AI model for a provider
+#'
+#' @param provider Provider name.
+#' @param model Optional model name supplied by the caller.
+#' @returns Model name, or `NULL` to use the provider default.
+#' @noRd
+.resolve_ai_model <- function(
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL)
+) {
+  provider <- .normalize_ai_provider(provider)
+  if (!is.null(model)) {
+    return(model)
+  }
+  if (identical(provider, "deepseek")) {
+    return("deepseek-chat")
+  }
+  NULL
+}
+
+#' Resolve an AI API key
+#'
+#' @param provider Provider name.
+#' @param api_key Optional explicit API key.
+#' @returns API key string.
+#' @noRd
+.get_api_key <- function(
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  api_key = getOption("glydet.ai_api_key", NULL)
+) {
+  if (!is.null(api_key) && nzchar(api_key)) {
+    return(api_key)
+  }
+  provider <- .normalize_ai_provider(provider)
+  envvar <- .ai_provider_envvar(provider)
+  api_key <- Sys.getenv(envvar)
   if (api_key == "") {
+    label <- .ai_provider_label(provider)
     cli::cli_abort(c(
-      "API key for DeepSeek chat model is not set.",
-      "i" = "Please set the environment variable `DEEPSEEK_API_KEY` to your API key.",
-      "i" = "You can obtain an API key from https://platform.deepseek.com."
+      "API key for {label} chat model is not set.",
+      "i" = "Please set the environment variable `{envvar}` to your API key, or pass `api_key` directly.",
+      "i" = "For OpenAI-compatible endpoints, set `OPENAI_API_KEY` and pass `base_url`."
     ))
   }
   api_key
 }
 
-.ask_ai <- function(system_prompt, user_prompt, model = "deepseek-chat") {
+#' Create an ellmer chat object for a configured provider
+#'
+#' @param system_prompt System prompt for the chat object.
+#' @param api_key API key for the selected provider.
+#' @param provider Provider name.
+#' @param model Optional model name.
+#' @param base_url Optional provider base URL.
+#' @returns An `ellmer` chat object.
+#' @noRd
+.create_ai_chat <- function(
+  system_prompt,
+  api_key,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
   rlang::check_installed("ellmer")
-  api_key <- .get_api_key()
-  chat <- ellmer::chat_deepseek(
+  provider <- .normalize_ai_provider(provider)
+  model <- .resolve_ai_model(provider, model)
+
+  args <- list(
     system_prompt = system_prompt,
     model = model,
     echo = "none",
     credentials = function() api_key
+  )
+  if (is.null(model)) {
+    args$model <- NULL
+  }
+
+  chat_fun <- switch(
+    provider,
+    deepseek = ellmer::chat_deepseek,
+    openai = ellmer::chat_openai,
+    anthropic = ellmer::chat_anthropic,
+    gemini = ellmer::chat_google_gemini,
+    openrouter = ellmer::chat_openrouter,
+    openai_compatible = ellmer::chat_openai_compatible
+  )
+
+  if (identical(provider, "openai_compatible")) {
+    if (is.null(base_url)) {
+      cli::cli_abort(
+        "`base_url` is required when `provider = \"openai_compatible\"`."
+      )
+    }
+    args <- c(list(base_url = base_url, name = "OpenAI-compatible"), args)
+  } else if (!is.null(base_url)) {
+    args$base_url <- base_url
+  }
+
+  do.call(chat_fun, args)
+}
+
+#' Send a text-only AI request
+#'
+#' @param system_prompt System prompt for the AI request.
+#' @param user_prompt User prompt for the AI request.
+#' @param api_key API key for the selected provider.
+#' @param model Optional model name.
+#' @param provider Provider name.
+#' @param base_url Optional provider base URL.
+#' @returns Character AI response.
+#' @noRd
+.ask_ai <- function(
+  system_prompt,
+  user_prompt,
+  api_key = getOption("glydet.ai_api_key", NULL),
+  model = getOption("glydet.ai_model", NULL),
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  base_url = getOption("glydet.ai_base_url", NULL)
+) {
+  api_key <- .get_api_key(provider = provider, api_key = api_key)
+  chat <- .create_ai_chat(
+    system_prompt = system_prompt,
+    api_key = api_key,
+    provider = provider,
+    model = model,
+    base_url = base_url
   )
   as.character(chat$chat(user_prompt))
 }

--- a/man/explain_trait.Rd
+++ b/man/explain_trait.Rd
@@ -4,7 +4,15 @@
 \alias{explain_trait}
 \title{Explain a Derived Trait}
 \usage{
-explain_trait(trait_fn, use_ai = FALSE, custom_mp = NULL)
+explain_trait(
+  trait_fn,
+  use_ai = FALSE,
+  custom_mp = NULL,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+)
 }
 \arguments{
 \item{trait_fn}{A derived trait function created by one of the trait factories.}
@@ -13,13 +21,28 @@ explain_trait(trait_fn, use_ai = FALSE, custom_mp = NULL)
 Whether to use a Large Language Model (LLM) to explain the trait. Default is FALSE.
 To use this feature, you need to install the \code{ellmer} package.
 DeepSeek is used by default for backward compatibility. Other \code{ellmer}
-providers can be selected with the \code{glydet.ai_provider},
-\code{glydet.ai_model}, \code{glydet.ai_api_key}, and \code{glydet.ai_base_url}
-package options.}
+providers can be selected with \code{provider}, \code{model}, and provider-specific
+API key configuration.}
 
 \item{custom_mp}{A named character vector of custom meta-properties.
 The names are the meta-property names, and the values are in the format
 "(type) description". Only used when \code{use_ai = TRUE}.}
+
+\item{provider}{AI provider passed to \code{ellmer} when \code{use_ai = TRUE}.
+One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
+"openai_compatible". Defaults to
+\code{getOption("glydet.ai_provider", "deepseek")}.}
+
+\item{model}{Model to use when \code{use_ai = TRUE}. Defaults to
+\code{getOption("glydet.ai_model")}, or "deepseek-chat" for DeepSeek and the
+provider default for other providers.}
+
+\item{api_key}{API key for the selected provider. If \code{NULL}, the provider
+specific environment variable is used. Defaults to
+\code{getOption("glydet.ai_api_key")}.}
+
+\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.
+Defaults to \code{getOption("glydet.ai_base_url")}.}
 }
 \value{
 A character string containing a concise English explanation of the trait.

--- a/man/explain_trait.Rd
+++ b/man/explain_trait.Rd
@@ -12,9 +12,10 @@ explain_trait(trait_fn, use_ai = FALSE, custom_mp = NULL)
 \item{use_ai}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Whether to use a Large Language Model (LLM) to explain the trait. Default is FALSE.
 To use this feature, you need to install the \code{ellmer} package.
-You also need to provide an API key for the DeepSeek chat model.
-Please set the environment variable \code{DEEPSEEK_API_KEY} to your API key.
-You can obtain an API key from https://platform.deepseek.com.}
+DeepSeek is used by default for backward compatibility. Other \code{ellmer}
+providers can be selected with the \code{glydet.ai_provider},
+\code{glydet.ai_model}, \code{glydet.ai_api_key}, and \code{glydet.ai_base_url}
+package options.}
 
 \item{custom_mp}{A named character vector of custom meta-properties.
 The names are the meta-property names, and the values are in the format

--- a/man/explain_trait.Rd
+++ b/man/explain_trait.Rd
@@ -30,7 +30,8 @@ The names are the meta-property names, and the values are in the format
 
 \item{provider}{AI provider passed to \code{ellmer} when \code{use_ai = TRUE}.
 One of "deepseek", "openai", "anthropic", "gemini", "openrouter", or
-"openai_compatible". Defaults to
+"openai_compatible". "google_gemini" is accepted as an alias for
+"gemini". Defaults to
 \code{getOption("glydet.ai_provider", "deepseek")}.}
 
 \item{model}{Model to use when \code{use_ai = TRUE}. Defaults to

--- a/man/make_trait.Rd
+++ b/man/make_trait.Rd
@@ -36,7 +36,8 @@ This is useful for inspecting how LLMs generate trait functions.}
 
 \item{provider}{AI provider passed to \code{ellmer}. One of "deepseek",
 "openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
-Defaults to \code{getOption("glydet.ai_provider", "deepseek")}.}
+"google_gemini" is accepted as an alias for "gemini". Defaults to
+\code{getOption("glydet.ai_provider", "deepseek")}.}
 
 \item{model}{Model to use. Defaults to \code{getOption("glydet.ai_model")},
 or "deepseek-chat" for DeepSeek and the provider default for other providers.}

--- a/man/make_trait.Rd
+++ b/man/make_trait.Rd
@@ -4,7 +4,16 @@
 \alias{make_trait}
 \title{Use a Large Language Model (LLM) to create a derived trait function}
 \usage{
-make_trait(description, custom_mp = NULL, max_retries = 2, verbose = FALSE)
+make_trait(
+  description,
+  custom_mp = NULL,
+  max_retries = 2,
+  verbose = FALSE,
+  provider = getOption("glydet.ai_provider", "deepseek"),
+  model = getOption("glydet.ai_model", NULL),
+  api_key = getOption("glydet.ai_api_key", NULL),
+  base_url = getOption("glydet.ai_base_url", NULL)
+)
 }
 \arguments{
 \item{description}{A description of the trait in natural language.}
@@ -24,6 +33,20 @@ formula's explanation doesn't match the original description. Default is 2.}
 
 \item{verbose}{Whether to print verbose output. Default is FALSE.
 This is useful for inspecting how LLMs generate trait functions.}
+
+\item{provider}{AI provider passed to \code{ellmer}. One of "deepseek",
+"openai", "anthropic", "gemini", "openrouter", or "openai_compatible".
+Defaults to \code{getOption("glydet.ai_provider", "deepseek")}.}
+
+\item{model}{Model to use. Defaults to \code{getOption("glydet.ai_model")},
+or "deepseek-chat" for DeepSeek and the provider default for other providers.}
+
+\item{api_key}{API key for the selected provider. If \code{NULL}, the provider
+specific environment variable is used. Defaults to
+\code{getOption("glydet.ai_api_key")}.}
+
+\item{base_url}{Optional base URL for custom or OpenAI-compatible endpoints.
+Defaults to \code{getOption("glydet.ai_base_url")}.}
 }
 \value{
 A derived trait function.
@@ -36,9 +59,9 @@ If the description is not clear, an error will be raised.
 Try to read the descriptions of built-in traits to get ideas.
 Currently, only \code{prop()}, \code{ratio()}, and \code{wmean()} are supported.
 To use this feature, you need to install the \code{ellmer} package.
-You also need to provide an API key for the DeepSeek chat model.
-Please set the environment variable \code{DEEPSEEK_API_KEY} to your API key using \code{Sys.setenv()}.
-You can obtain an API key from https://platform.deepseek.com.
+DeepSeek is used by default for backward compatibility. Other \code{ellmer}
+providers can be selected with \code{provider}, \code{model}, and provider-specific
+API key configuration.
 }
 \examples{
 # Sys.setenv(DEEPSEEK_API_KEY = "your_api_key")

--- a/tests/testthat/test-explain-trait.R
+++ b/tests/testthat/test-explain-trait.R
@@ -264,10 +264,47 @@ test_that("explain_trait works for wsum traits", {
   )
 })
 
-test_that("explain_trait works with use_ai = TURE", {
-  local_mocked_bindings(.ask_ai = function(system_prompt, user_prompt) "AI response")
+test_that("explain_trait works with use_ai = TRUE", {
+  local_mocked_bindings(.ask_ai = function(...) "AI response")
   expect_equal(
     explain_trait(prop(nFc > 0), use_ai = TRUE),
     "AI response"
   )
+})
+
+test_that("explain_trait passes explicit AI provider settings", {
+  captured <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    .ask_ai = function(
+      system_prompt,
+      user_prompt,
+      api_key = NULL,
+      model = NULL,
+      provider = NULL,
+      base_url = NULL
+    ) {
+      captured$api_key <- api_key
+      captured$model <- model
+      captured$provider <- provider
+      captured$base_url <- base_url
+      "AI response"
+    }
+  )
+
+  expect_equal(
+    explain_trait(
+      prop(nFc > 0),
+      use_ai = TRUE,
+      provider = "openai",
+      model = "gpt-4o-mini",
+      api_key = "openai-key",
+      base_url = "https://example.test/v1"
+    ),
+    "AI response"
+  )
+
+  expect_equal(captured$provider, "openai")
+  expect_equal(captured$model, "gpt-4o-mini")
+  expect_equal(captured$api_key, "openai-key")
+  expect_equal(captured$base_url, "https://example.test/v1")
 })

--- a/tests/testthat/test-make-trait.R
+++ b/tests/testthat/test-make-trait.R
@@ -15,7 +15,7 @@ test_that("make_trait works when AI response is valid and consistent", {
 
   # Mock explain_trait with use_ai = TRUE to return consistent explanation
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL, ...) {
       if (use_ai) {
         return("Proportion of sialylated glycans among all glycans.")
       }
@@ -49,11 +49,20 @@ test_that("make_trait routes explicit provider settings to ellmer", {
   )
 
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(
+      trait_fn,
+      use_ai = FALSE,
+      custom_mp = NULL,
+      api_key = NULL,
+      model = NULL,
+      provider = NULL,
+      base_url = NULL
+    ) {
       if (use_ai) {
-        expect_equal(getOption("glydet.ai_provider"), "openai")
-        expect_equal(getOption("glydet.ai_model"), "gpt-4o-mini")
-        expect_equal(getOption("glydet.ai_api_key"), "openai-key")
+        captured$explain_api_key <- api_key
+        captured$explain_model <- model
+        captured$explain_provider <- provider
+        captured$explain_base_url <- base_url
       }
       "Proportion of sialylated glycans among all glycans."
     }
@@ -88,6 +97,10 @@ test_that("make_trait routes explicit provider settings to ellmer", {
   expect_equal(captured$model, "gpt-4o-mini")
   expect_equal(captured$echo, "none")
   expect_equal(captured$api_key, "openai-key")
+  expect_equal(captured$explain_provider, "openai")
+  expect_equal(captured$explain_model, "gpt-4o-mini")
+  expect_equal(captured$explain_api_key, "openai-key")
+  expect_null(captured$explain_base_url)
   expect_equal(captured$consistency_provider, "openai")
   expect_equal(captured$consistency_model, "gpt-4o-mini")
   expect_equal(captured$consistency_api_key, "openai-key")
@@ -113,7 +126,7 @@ test_that("make_trait uses package-level AI provider options", {
   )
 
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL, ...) {
       "Proportion of sialylated glycans among all glycans."
     },
     .ask_ai = function(...) "YES"
@@ -148,7 +161,7 @@ test_that("make_trait supports OpenAI-compatible endpoints", {
   )
 
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL, ...) {
       "Proportion of sialylated glycans among all glycans."
     },
     .ask_ai = function(...) "YES"
@@ -195,7 +208,7 @@ test_that("make_trait retries when explanation is inconsistent", {
 
   # Mock explain_trait
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL, ...) {
       if (use_ai) {
         attr_val <- attr(trait_fn, "cond")
         if (!is.null(attr_val) && rlang::expr_text(attr_val) == "nF > 0") {
@@ -254,7 +267,7 @@ test_that("make_trait raises an error after max retries with inconsistent explan
 
   # Mock explain_trait
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL, ...) {
       if (use_ai) {
         return("Proportion of fucosylated glycans among all glycans.")
       }
@@ -303,7 +316,7 @@ test_that("custom_mp works with make_trait", {
 
   # Mock explain_trait
   local_mocked_bindings(
-    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL, ...) {
       if (use_ai) {
         return("Proportion of glycans with a2,6-linked sialic acids.")
       }

--- a/tests/testthat/test-make-trait.R
+++ b/tests/testthat/test-make-trait.R
@@ -1,6 +1,6 @@
 test_that("make_trait works when AI response is valid and consistent", {
   # Mock .get_api_key to avoid needing actual API key
-  local_mocked_bindings(.get_api_key = function() "mock_key")
+  local_mocked_bindings(.get_api_key = function(...) "mock_key")
 
   # Mock the chat object
   mock_chat <- list(
@@ -25,7 +25,7 @@ test_that("make_trait works when AI response is valid and consistent", {
 
   # Mock the consistency check to return YES
   local_mocked_bindings(
-    .ask_ai = function(system_prompt, user_prompt, model = "deepseek-chat") {
+    .ask_ai = function(...) {
       "YES"
     }
   )
@@ -34,9 +34,143 @@ test_that("make_trait works when AI response is valid and consistent", {
   expect_s3_class(res, "glydet_prop")
 })
 
+test_that("make_trait routes explicit provider settings to ellmer", {
+  captured <- new.env(parent = emptyenv())
+
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, model, echo, credentials) {
+      captured$system_prompt <- system_prompt
+      captured$model <- model
+      captured$echo <- echo
+      captured$api_key <- credentials()
+      list(chat = function(prompt) "prop(nS > 0)")
+    },
+    .package = "ellmer"
+  )
+
+  local_mocked_bindings(
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+      if (use_ai) {
+        expect_equal(getOption("glydet.ai_provider"), "openai")
+        expect_equal(getOption("glydet.ai_model"), "gpt-4o-mini")
+        expect_equal(getOption("glydet.ai_api_key"), "openai-key")
+      }
+      "Proportion of sialylated glycans among all glycans."
+    }
+  )
+
+  local_mocked_bindings(
+    .ask_ai = function(
+      system_prompt,
+      user_prompt,
+      api_key = NULL,
+      model = NULL,
+      provider = NULL,
+      base_url = NULL
+    ) {
+      captured$consistency_api_key <- api_key
+      captured$consistency_model <- model
+      captured$consistency_provider <- provider
+      captured$consistency_base_url <- base_url
+      "YES"
+    }
+  )
+
+  res <- make_trait(
+    "proportion of sialylated glycans",
+    provider = "openai",
+    model = "gpt-4o-mini",
+    api_key = "openai-key"
+  )
+
+  expect_s3_class(res, "glydet_prop")
+  expect_match(captured$system_prompt, "professional glycobiologist")
+  expect_equal(captured$model, "gpt-4o-mini")
+  expect_equal(captured$echo, "none")
+  expect_equal(captured$api_key, "openai-key")
+  expect_equal(captured$consistency_provider, "openai")
+  expect_equal(captured$consistency_model, "gpt-4o-mini")
+  expect_equal(captured$consistency_api_key, "openai-key")
+  expect_null(captured$consistency_base_url)
+})
+
+test_that("make_trait uses package-level AI provider options", {
+  captured <- new.env(parent = emptyenv())
+  old_options <- options(
+    glydet.ai_provider = "openai",
+    glydet.ai_model = "gpt-4o-mini",
+    glydet.ai_api_key = "option-key"
+  )
+  on.exit(options(old_options), add = TRUE)
+
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, model, echo, credentials) {
+      captured$model <- model
+      captured$api_key <- credentials()
+      list(chat = function(prompt) "prop(nS > 0)")
+    },
+    .package = "ellmer"
+  )
+
+  local_mocked_bindings(
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+      "Proportion of sialylated glycans among all glycans."
+    },
+    .ask_ai = function(...) "YES"
+  )
+
+  res <- make_trait("proportion of sialylated glycans")
+
+  expect_s3_class(res, "glydet_prop")
+  expect_equal(captured$model, "gpt-4o-mini")
+  expect_equal(captured$api_key, "option-key")
+})
+
+test_that("make_trait supports OpenAI-compatible endpoints", {
+  captured <- new.env(parent = emptyenv())
+
+  local_mocked_bindings(
+    chat_openai_compatible = function(
+      base_url,
+      name,
+      system_prompt,
+      model = NULL,
+      echo,
+      credentials
+    ) {
+      captured$base_url <- base_url
+      captured$name <- name
+      captured$model <- model
+      captured$api_key <- credentials()
+      list(chat = function(prompt) "prop(nS > 0)")
+    },
+    .package = "ellmer"
+  )
+
+  local_mocked_bindings(
+    explain_trait = function(trait_fn, use_ai = FALSE, custom_mp = NULL) {
+      "Proportion of sialylated glycans among all glycans."
+    },
+    .ask_ai = function(...) "YES"
+  )
+
+  res <- make_trait(
+    "proportion of sialylated glycans",
+    provider = "openai_compatible",
+    api_key = "compatible-key",
+    base_url = "https://example.test/v1"
+  )
+
+  expect_s3_class(res, "glydet_prop")
+  expect_equal(captured$base_url, "https://example.test/v1")
+  expect_equal(captured$name, "OpenAI-compatible")
+  expect_null(captured$model)
+  expect_equal(captured$api_key, "compatible-key")
+})
+
 test_that("make_trait retries when explanation is inconsistent", {
   # Mock .get_api_key
-  local_mocked_bindings(.get_api_key = function() "mock_key")
+  local_mocked_bindings(.get_api_key = function(...) "mock_key")
 
   call_count <- 0
 
@@ -76,7 +210,7 @@ test_that("make_trait retries when explanation is inconsistent", {
   # Mock consistency check: NO for first, YES for second
   consistency_call_count <- 0
   local_mocked_bindings(
-    .ask_ai = function(system_prompt, user_prompt, model = "deepseek-chat") {
+    .ask_ai = function(...) {
       consistency_call_count <<- consistency_call_count + 1
       if (consistency_call_count == 1) "NO" else "YES"
     }
@@ -89,7 +223,7 @@ test_that("make_trait retries when explanation is inconsistent", {
 
 test_that("make_trait raises an error when AI response is invalid", {
   # Mock .get_api_key
-  local_mocked_bindings(.get_api_key = function() "mock_key")
+  local_mocked_bindings(.get_api_key = function(...) "mock_key")
 
   # Mock the chat object
   mock_chat <- list(
@@ -106,7 +240,7 @@ test_that("make_trait raises an error when AI response is invalid", {
 
 test_that("make_trait raises an error after max retries with inconsistent explanations", {
   # Mock .get_api_key
-  local_mocked_bindings(.get_api_key = function() "mock_key")
+  local_mocked_bindings(.get_api_key = function(...) "mock_key")
 
   # Mock the chat object
   mock_chat <- list(
@@ -130,7 +264,7 @@ test_that("make_trait raises an error after max retries with inconsistent explan
 
   # Always return NO for consistency
   local_mocked_bindings(
-    .ask_ai = function(system_prompt, user_prompt, model = "deepseek-chat") "NO"
+    .ask_ai = function(...) "NO"
   )
 
   expect_error(
@@ -154,7 +288,7 @@ test_that("custom_mp parameter includes custom meta-properties in system prompt"
 
 test_that("custom_mp works with make_trait", {
   # Mock .get_api_key
-  local_mocked_bindings(.get_api_key = function() "mock_key")
+  local_mocked_bindings(.get_api_key = function(...) "mock_key")
 
   captured_system_prompt <- NULL
 
@@ -179,7 +313,7 @@ test_that("custom_mp works with make_trait", {
 
   # Mock the consistency check to return YES
   local_mocked_bindings(
-    .ask_ai = function(system_prompt, user_prompt, model = "deepseek-chat") "YES"
+    .ask_ai = function(...) "YES"
   )
 
   custom_mp <- c(nE = "(integer) number of a2,6-linked sialic acids")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,85 @@
+test_that("optional AI strings treat empty values as missing", {
+  old_key <- Sys.getenv("OPENAI_API_KEY", unset = NA_character_)
+  Sys.unsetenv("OPENAI_API_KEY")
+  on.exit(
+    if (is.na(old_key)) {
+      Sys.unsetenv("OPENAI_API_KEY")
+    } else {
+      Sys.setenv(OPENAI_API_KEY = old_key)
+    },
+    add = TRUE
+  )
+
+  expect_error(
+    make_trait(
+      "proportion of sialylated glycans",
+      provider = "openai",
+      model = "",
+      api_key = "",
+      base_url = ""
+    ),
+    "API key for OpenAI chat model"
+  )
+})
+
+test_that("empty optional AI model and base URL are omitted from chat args", {
+  captured <- new.env(parent = emptyenv())
+
+  local_mocked_bindings(
+    chat_openai = function(system_prompt, echo, credentials, ...) {
+      captured$args <- list(...)
+      list(chat = function(prompt) "AI response")
+    },
+    .package = "ellmer"
+  )
+
+  .create_ai_chat(
+    system_prompt = "system",
+    api_key = "openai-key",
+    provider = "openai",
+    model = "",
+    base_url = ""
+  )
+
+  expect_false("model" %in% names(captured$args))
+  expect_false("base_url" %in% names(captured$args))
+})
+
+test_that("missing API key guidance is provider-specific", {
+  old_deepseek_key <- Sys.getenv("DEEPSEEK_API_KEY", unset = NA_character_)
+  old_openai_key <- Sys.getenv("OPENAI_API_KEY", unset = NA_character_)
+  Sys.unsetenv("DEEPSEEK_API_KEY")
+  Sys.unsetenv("OPENAI_API_KEY")
+  on.exit(
+    {
+      if (is.na(old_deepseek_key)) {
+        Sys.unsetenv("DEEPSEEK_API_KEY")
+      } else {
+        Sys.setenv(DEEPSEEK_API_KEY = old_deepseek_key)
+      }
+      if (is.na(old_openai_key)) {
+        Sys.unsetenv("OPENAI_API_KEY")
+      } else {
+        Sys.setenv(OPENAI_API_KEY = old_openai_key)
+      }
+    },
+    add = TRUE
+  )
+
+  deepseek_error <- tryCatch(
+    .get_api_key(provider = "deepseek"),
+    error = function(e) conditionMessage(e)
+  )
+  compatible_error <- tryCatch(
+    .get_api_key(provider = "openai_compatible"),
+    error = function(e) conditionMessage(e)
+  )
+
+  expect_match(deepseek_error, "DEEPSEEK_API_KEY")
+  expect_no_match(deepseek_error, "OpenAI-compatible")
+  expect_match(compatible_error, "OpenAI-compatible endpoints")
+})
+
+test_that("google_gemini is accepted as a Gemini provider alias", {
+  expect_equal(.normalize_ai_provider("google_gemini"), "gemini")
+})

--- a/vignettes/custom-traits.Rmd
+++ b/vignettes/custom-traits.Rmd
@@ -421,7 +421,9 @@ or when collaborating with team members who need to understand your analytical a
 We have introduced a new argument `use_ai` to `explain_trait()` since glydet 0.7.0.
 If `use_ai` is TRUE, the function will use a Large Language Model (LLM) to explain the trait,
 which covers more complex cases and edge cases.
-Check out the documentation of `explain_trait()` for details.
+You can pass the same AI configuration arguments used by `make_trait()`, such as
+`provider`, `model`, `api_key`, and `base_url`.
+Check out the documentation of `explain_trait()` and `make_trait()` for details.
 
 ## Custom Meta-Properties
 

--- a/vignettes/custom-traits.Rmd
+++ b/vignettes/custom-traits.Rmd
@@ -591,14 +591,36 @@ rename or overwrite meta-properties.
 
 `make_trait()` allows you to create a trait from natural language.
 To use this feature, you need to install the `ellmer` package (not a forced dependency of `glydet`).
-You also need to provide an API key for the DeepSeek chat model.
-You can obtain an API key from https://platform.deepseek.com.
-Please set the environment variable `DEEPSEEK_API_KEY` to your API key using `Sys.setenv()`:
+DeepSeek is used by default for backward compatibility.
+You can obtain a DeepSeek API key from https://platform.deepseek.com and set it with `Sys.setenv()`:
 
 ```r
 # Works for a single session
 Sys.setenv(DEEPSEEK_API_KEY = "your_api_key")
 ```
+
+You can also use other `ellmer` providers by passing provider settings directly:
+
+```r
+make_trait(
+  "the average number of sialic acids",
+  provider = "openai",
+  model = "gpt-4o-mini",
+  api_key = Sys.getenv("OPENAI_API_KEY")
+)
+```
+
+Or configure defaults once per session:
+
+```r
+options(
+  glydet.ai_provider = "openai",
+  glydet.ai_model = "gpt-4o-mini",
+  glydet.ai_api_key = Sys.getenv("OPENAI_API_KEY")
+)
+```
+
+For OpenAI-compatible endpoints, set `provider = "openai_compatible"` and pass `base_url`.
 
 Then you can transform your ideas into trait functions by calling `make_trait()`:
 

--- a/vignettes/custom-traits.Rmd
+++ b/vignettes/custom-traits.Rmd
@@ -623,6 +623,7 @@ options(
 ```
 
 For OpenAI-compatible endpoints, set `provider = "openai_compatible"` and pass `base_url`.
+For Gemini, use `provider = "gemini"`; `provider = "google_gemini"` is also accepted as an alias.
 
 Then you can transform your ideas into trait functions by calling `make_trait()`:
 


### PR DESCRIPTION
## Summary
- Extend `make_trait()` and AI-enabled `explain_trait()` with `provider`, `model`, `api_key`, and `base_url` configuration.
- Add shared AI helper plumbing for DeepSeek, OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints.
- Keep DeepSeek as the default while allowing session-level defaults through `glydet.ai_*` options.
- Update tests, Rd files, vignette guidance, and NEWS to match the new interface.

## Testing
- Added unit coverage for explicit provider routing, package-option defaults, and OpenAI-compatible endpoints.
- Ran the full `devtools::test()` suite locally and confirmed it passes.
- Regenerated documentation with `devtools::document()`.

Closes #11