### PR TITLE
feat: add sia_link parameter for sialic acid linkage traits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glydet (development version)
 
+## New features
+
+* `basic_traits()` and `all_traits()` now support an optional `sia_link` parameter. When set to `TRUE`, additional sialic acid linkage traits are included: `GE`, `GL`, `TE`, `TL` (in `basic_traits()`), and `A1E`–`A4E`, `A1L`–`A4L`, `A1GE`–`A4GE`, `A1GL`–`A4GL` (in `all_traits()`). These traits require `nE` and `nL` columns in `var_info` (#9).
+
 ## Minor improvements and bug fixes
 
 * `make_trait()` and AI-enabled `explain_trait()` now support configurable `ellmer` providers, including OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible endpoints, with `glydet.ai_*` package options for session defaults (#14).

--- a/R/glydet-traits.R
+++ b/R/glydet-traits.R
@@ -27,18 +27,18 @@
 #'
 #' Two additional sialic acid linkage traits are included if `sia_link = TRUE`.
 #'
-#' - `GE`: Average degree of α2,6-linked sialylation per galactose
-#' - `GL`: Average degree of α2,3-linked sialylation per galactose
-#' - `TE`: Proportion of α2,6-linked sialylated glycans
-#' - `TL`: Proportion of α2,3-linked sialylated glycans
+#' - `GE`: Average degree of a2,6-linked sialylation per galactose
+#' - `GL`: Average degree of a2,3-linked sialylation per galactose
+#' - `TE`: Proportion of a2,6-linked sialylated glycans
+#' - `TL`: Proportion of a2,3-linked sialylated glycans
 #'
 #' # Usage of sialic acid linkage traits
 #'
 #' To use these sialic acid linkage traits,
 #' `var_info` of the input `glyexp::experiment()` must have the following columns:
 #'
-#' - `nE`: Number of α2,6-linked sialic acids
-#' - `nL`: Number of α2,3-linked sialic acids
+#' - `nE`: Number of a2,6-linked sialic acids
+#' - `nL`: Number of a2,3-linked sialic acids
 #'
 #' Note that you have to add these two columns even if the `glycan_structure` column has intact linkages.
 #' This is because by convention all traits work with glycan structures with "basic" structure levels
@@ -85,13 +85,13 @@ basic_traits <- function(sia_link = FALSE) {
   if (sia_link) {
     cli::cli_alert_info("Please ensure that {.field nE} and {.field nL} are in {.field var_info}. See {.code ?basic_traits} for details.")
     sia_traits <- list(
-      # Average degree of α2,6-linked sialylation per galactose
+      # Average degree of a2,6-linked sialylation per galactose
       GE = wmean(nE / nG),
-      # Average degree of α2,3-linked sialylation per galactose
+      # Average degree of a2,3-linked sialylation per galactose
       GL = wmean(nL / nG),
-      # Proportion of α2,6-linked sialylated glycans
+      # Proportion of a2,6-linked sialylated glycans
       TE = prop(nE > 0),
-      # Proportion of α2,3-linked sialylated glycans
+      # Proportion of a2,3-linked sialylated glycans
       TL = prop(nL > 0)
     )
     traits <- c(traits, sia_traits)

--- a/R/glydet-traits.R
+++ b/R/glydet-traits.R
@@ -54,6 +54,7 @@
 #'
 #' @export
 basic_traits <- function(sia_link = FALSE) {
+  checkmate::assert_flag(sia_link)
   traits <- list(
     # Proportion of highmannose glycans
     TM = prop(Tp == "highmannose"),
@@ -188,6 +189,7 @@ basic_traits <- function(sia_link = FALSE) {
 #'
 #' @export
 all_traits <- function(sia_link = FALSE) {
+  checkmate::assert_flag(sia_link)
   additional_traits <- list(
 
     # ===== Advanced Fucosylation Traits =====

--- a/R/glydet-traits.R
+++ b/R/glydet-traits.R
@@ -44,6 +44,8 @@
 #' This is because by convention all traits work with glycan structures with "basic" structure levels
 #' (i.e., with generic monosaccharides like "Hex" and "HexNAc" and no linkages specified).
 #'
+#' @param sia_link A boolean indicating whether to include sialic acid linkage traits. Default is `FALSE`.
+#'
 #' @returns
 #' A named list of derived traits.
 #'
@@ -177,7 +179,7 @@ basic_traits <- function(sia_link = FALSE) {
 #' - `A4GL`: Average degree of a2,3-linked sialylation per galactose within tetra-antennary glycans
 #'
 #' @inheritSection basic_traits Usage of sialic acid linkage traits
-#'
+#' @inheritParams basic_traits
 #' @returns
 #' A named list of derived traits.
 #'

--- a/R/glydet-traits.R
+++ b/R/glydet-traits.R
@@ -6,6 +6,8 @@
 #' and branching level.
 #'
 #' @details
+#' # Descriptions of traits
+#'
 #' The explanations of the derived traits are as follows:
 #'
 #' - `TM`: Proportion of highmannose glycans
@@ -23,6 +25,25 @@
 #' - `AG`: Average degree of galactosylation per antenna
 #' - `TS`: Proportion of sialylated glycans
 #'
+#' Two additional sialic acid linkage traits are included if `sia_link = TRUE`.
+#'
+#' - `GE`: Average degree of α2,6-linked sialylation per galactose
+#' - `GL`: Average degree of α2,3-linked sialylation per galactose
+#' - `TE`: Proportion of α2,6-linked sialylated glycans
+#' - `TL`: Proportion of α2,3-linked sialylated glycans
+#'
+#' # Usage of sialic acid linkage traits
+#'
+#' To use these sialic acid linkage traits,
+#' `var_info` of the input `glyexp::experiment()` must have the following columns:
+#'
+#' - `nE`: Number of α2,6-linked sialic acids
+#' - `nL`: Number of α2,3-linked sialic acids
+#'
+#' Note that you have to add these two columns even if the `glycan_structure` column has intact linkages.
+#' This is because by convention all traits work with glycan structures with "basic" structure levels
+#' (i.e., with generic monosaccharides like "Hex" and "HexNAc" and no linkages specified).
+#'
 #' @returns
 #' A named list of derived traits.
 #'
@@ -30,8 +51,8 @@
 #' basic_traits()
 #'
 #' @export
-basic_traits <- function() {
-  list(
+basic_traits <- function(sia_link = FALSE) {
+  traits <- list(
     # Proportion of highmannose glycans
     TM = prop(Tp == "highmannose"),
     # Proportion of hybrid glycans
@@ -61,6 +82,21 @@ basic_traits <- function() {
     # Proportion of sialylated glycans
     TS = prop(nS > 0)
   )
+  if (sia_link) {
+    cli::cli_alert_info("Please ensure that {.field nE} and {.field nL} are in {.field var_info}. See {.code ?basic_traits} for details.")
+    sia_traits <- list(
+      # Average degree of α2,6-linked sialylation per galactose
+      GE = wmean(nE / nG),
+      # Average degree of α2,3-linked sialylation per galactose
+      GL = wmean(nL / nG),
+      # Proportion of α2,6-linked sialylated glycans
+      TE = prop(nE > 0),
+      # Proportion of α2,3-linked sialylated glycans
+      TL = prop(nL > 0)
+    )
+    traits <- c(traits, sia_traits)
+  }
+  traits
 }
 
 #' Get All Derived Traits
@@ -121,6 +157,27 @@ basic_traits <- function() {
 #' - `A3GS`: Average degree of sialylation per galactose within tri-antennary glycans
 #' - `A4GS`: Average degree of sialylation per galactose within tetra-antennary glycans
 #'
+#' These additional sialic acid linkage traits are included if `sia_link = TRUE`.
+#'
+#' - `A1E`: Average degree of a2,6-linked sialylation per antenna within mono-antennary glycans
+#' - `A2E`: Average degree of a2,6-linked sialylation per antenna within bi-antennary glycans
+#' - `A3E`: Average degree of a2,6-linked sialylation per antenna within tri-antennary glycans
+#' - `A4E`: Average degree of a2,6-linked sialylation per antenna within tetra-antennary glycans
+#' - `A1L`: Average degree of a2,3-linked sialylation per antenna within mono-antennary glycans
+#' - `A2L`: Average degree of a2,3-linked sialylation per antenna within bi-antennary glycans
+#' - `A3L`: Average degree of a2,3-linked sialylation per antenna within tri-antennary glycans
+#' - `A4L`: Average degree of a2,3-linked sialylation per antenna within tetra-antennary glycans
+#' - `A1GE`: Average degree of a2,6-linked sialylation per galactose within mono-antennary glycans
+#' - `A2GE`: Average degree of a2,6-linked sialylation per galactose within bi-antennary glycans
+#' - `A3GE`: Average degree of a2,6-linked sialylation per galactose within tri-antennary glycans
+#' - `A4GE`: Average degree of a2,6-linked sialylation per galactose within tetra-antennary glycans
+#' - `A1GL`: Average degree of a2,3-linked sialylation per galactose within mono-antennary glycans
+#' - `A2GL`: Average degree of a2,3-linked sialylation per galactose within bi-antennary glycans
+#' - `A3GL`: Average degree of a2,3-linked sialylation per galactose within tri-antennary glycans
+#' - `A4GL`: Average degree of a2,3-linked sialylation per galactose within tetra-antennary glycans
+#'
+#' @inheritSection basic_traits Usage of sialic acid linkage traits
+#'
 #' @returns
 #' A named list of derived traits.
 #'
@@ -128,7 +185,7 @@ basic_traits <- function() {
 #' all_traits()
 #'
 #' @export
-all_traits <- function() {
+all_traits <- function(sia_link = FALSE) {
   additional_traits <- list(
 
     # ===== Advanced Fucosylation Traits =====
@@ -252,8 +309,48 @@ all_traits <- function() {
     A4GS = wmean(nS / nG, within = (nA == 4))
   )
 
-  c(basic_traits(), additional_traits)
+  traits <- c(suppressMessages(basic_traits(sia_link)), additional_traits)
+
+  if (sia_link) {
+    cli::cli_alert_info("Please ensure that {.field nE} and {.field nL} are in {.field var_info}. See {.code ?all_traits} for details.")
+    sia_traits <- list(
+      # Average degree of a2,6-linked sialylation per antenna within mono-antennary glycans
+      A1E = wmean(nE / nA, within = (nA == 1)),
+      # Average degree of a2,6-linked sialylation per antenna within bi-antennary glycans
+      A2E = wmean(nE / nA, within = (nA == 2)),
+      # Average degree of a2,6-linked sialylation per antenna within tri-antennary glycans
+      A3E = wmean(nE / nA, within = (nA == 3)),
+      # Average degree of a2,6-linked sialylation per antenna within tetra-antennary glycans
+      A4E = wmean(nE / nA, within = (nA == 4)),
+      # Average degree of a2,3-linked sialylation per antenna within mono-antennary glycans
+      A1L = wmean(nL / nA, within = (nA == 1)),
+      # Average degree of a2,3-linked sialylation per antenna within bi-antennary glycans
+      A2L = wmean(nL / nA, within = (nA == 2)),
+      # Average degree of a2,3-linked sialylation per antenna within tri-antennary glycans
+      A3L = wmean(nL / nA, within = (nA == 3)),
+      # Average degree of a2,3-linked sialylation per antenna within tetra-antennary glycans
+      A4L = wmean(nL / nA, within = (nA == 4)),
+      # Average degree of a2,6-linked sialylation per galactose within mono-antennary glycans
+      A1GE = wmean(nE / nG, within = (nA == 1)),
+      # Average degree of a2,6-linked sialylation per galactose within bi-antennary glycans
+      A2GE = wmean(nE / nG, within = (nA == 2)),
+      # Average degree of a2,6-linked sialylation per galactose within tri-antennary glycans
+      A3GE = wmean(nE / nG, within = (nA == 3)),
+      # Average degree of a2,6-linked sialylation per galactose within tetra-antennary glycans
+      A4GE = wmean(nE / nG, within = (nA == 4)),
+      # Average degree of a2,3-linked sialylation per galactose within mono-antennary glycans
+      A1GL = wmean(nL / nG, within = (nA == 1)),
+      # Average degree of a2,3-linked sialylation per galactose within bi-antennary glycans
+      A2GL = wmean(nL / nG, within = (nA == 2)),
+      # Average degree of a2,3-linked sialylation per galactose within tri-antennary glycans
+      A3GL = wmean(nL / nG, within = (nA == 3)),
+      # Average degree of a2,3-linked sialylation per galactose within tetra-antennary glycans
+      A4GL = wmean(nL / nG, within = (nA == 4))
+    )
+    traits <- c(traits, sia_traits)
+  }
+  traits
 }
 
 # To avoid note about global variables in R CMD check
-Tp <- nM <- nA <- nF <- nFc <- nFa <- nG <- nS <- nGt <- nT <- B <- NULL
+Tp <- nM <- nA <- nF <- nFc <- nFa <- nG <- nS <- nE <- nL <- nGt <- nT <- B <- NULL

--- a/R/glydet-traits.R
+++ b/R/glydet-traits.R
@@ -25,7 +25,7 @@
 #' - `AG`: Average degree of galactosylation per antenna
 #' - `TS`: Proportion of sialylated glycans
 #'
-#' Two additional sialic acid linkage traits are included if `sia_link = TRUE`.
+#' Four additional sialic acid linkage traits are included if `sia_link = TRUE`.
 #'
 #' - `GE`: Average degree of a2,6-linked sialylation per galactose
 #' - `GL`: Average degree of a2,3-linked sialylation per galactose

--- a/man/all_traits.Rd
+++ b/man/all_traits.Rd
@@ -4,7 +4,7 @@
 \alias{all_traits}
 \title{Get All Derived Traits}
 \usage{
-all_traits()
+all_traits(sia_link = FALSE)
 }
 \value{
 A named list of derived traits.
@@ -66,7 +66,40 @@ The explanations of the derived traits are as follows:
 \item \code{A3GS}: Average degree of sialylation per galactose within tri-antennary glycans
 \item \code{A4GS}: Average degree of sialylation per galactose within tetra-antennary glycans
 }
+
+These additional sialic acid linkage traits are included if \code{sia_link = TRUE}.
+\itemize{
+\item \code{A1E}: Average degree of a2,6-linked sialylation per antenna within mono-antennary glycans
+\item \code{A2E}: Average degree of a2,6-linked sialylation per antenna within bi-antennary glycans
+\item \code{A3E}: Average degree of a2,6-linked sialylation per antenna within tri-antennary glycans
+\item \code{A4E}: Average degree of a2,6-linked sialylation per antenna within tetra-antennary glycans
+\item \code{A1L}: Average degree of a2,3-linked sialylation per antenna within mono-antennary glycans
+\item \code{A2L}: Average degree of a2,3-linked sialylation per antenna within bi-antennary glycans
+\item \code{A3L}: Average degree of a2,3-linked sialylation per antenna within tri-antennary glycans
+\item \code{A4L}: Average degree of a2,3-linked sialylation per antenna within tetra-antennary glycans
+\item \code{A1GE}: Average degree of a2,6-linked sialylation per galactose within mono-antennary glycans
+\item \code{A2GE}: Average degree of a2,6-linked sialylation per galactose within bi-antennary glycans
+\item \code{A3GE}: Average degree of a2,6-linked sialylation per galactose within tri-antennary glycans
+\item \code{A4GE}: Average degree of a2,6-linked sialylation per galactose within tetra-antennary glycans
+\item \code{A1GL}: Average degree of a2,3-linked sialylation per galactose within mono-antennary glycans
+\item \code{A2GL}: Average degree of a2,3-linked sialylation per galactose within bi-antennary glycans
+\item \code{A3GL}: Average degree of a2,3-linked sialylation per galactose within tri-antennary glycans
+\item \code{A4GL}: Average degree of a2,3-linked sialylation per galactose within tetra-antennary glycans
 }
+}
+\section{Usage of sialic acid linkage traits}{
+To use these sialic acid linkage traits,
+\code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
+\itemize{
+\item \code{nE}: Number of α2,6-linked sialic acids
+\item \code{nL}: Number of α2,3-linked sialic acids
+}
+
+Note that you have to add these two columns even if the \code{glycan_structure} column has intact linkages.
+This is because by convention all traits work with glycan structures with "basic" structure levels
+(i.e., with generic monosaccharides like "Hex" and "HexNAc" and no linkages specified).
+}
+
 \examples{
 all_traits()
 

--- a/man/all_traits.Rd
+++ b/man/all_traits.Rd
@@ -91,8 +91,8 @@ These additional sialic acid linkage traits are included if \code{sia_link = TRU
 To use these sialic acid linkage traits,
 \code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
 \itemize{
-\item \code{nE}: Number of α2,6-linked sialic acids
-\item \code{nL}: Number of α2,3-linked sialic acids
+\item \code{nE}: Number of a2,6-linked sialic acids
+\item \code{nL}: Number of a2,3-linked sialic acids
 }
 
 Note that you have to add these two columns even if the \code{glycan_structure} column has intact linkages.

--- a/man/all_traits.Rd
+++ b/man/all_traits.Rd
@@ -6,6 +6,9 @@
 \usage{
 all_traits(sia_link = FALSE)
 }
+\arguments{
+\item{sia_link}{A boolean indicating whether to include sialic acid linkage traits. Default is \code{FALSE}.}
+}
 \value{
 A named list of derived traits.
 }

--- a/man/basic_traits.Rd
+++ b/man/basic_traits.Rd
@@ -37,7 +37,7 @@ The explanations of the derived traits are as follows:
 \item \code{TS}: Proportion of sialylated glycans
 }
 
-Two additional sialic acid linkage traits are included if \code{sia_link = TRUE}.
+Four additional sialic acid linkage traits are included if \code{sia_link = TRUE}.
 \itemize{
 \item \code{GE}: Average degree of a2,6-linked sialylation per galactose
 \item \code{GL}: Average degree of a2,3-linked sialylation per galactose

--- a/man/basic_traits.Rd
+++ b/man/basic_traits.Rd
@@ -4,7 +4,7 @@
 \alias{basic_traits}
 \title{Get Basic Derived Traits}
 \usage{
-basic_traits()
+basic_traits(sia_link = FALSE)
 }
 \value{
 A named list of derived traits.
@@ -15,7 +15,7 @@ They describe global properties of a glycome including the type of glycans,
 fucosylation level, sialylation level, galactosylation level,
 and branching level.
 }
-\details{
+\section{Descriptions of traits}{
 The explanations of the derived traits are as follows:
 \itemize{
 \item \code{TM}: Proportion of highmannose glycans
@@ -33,7 +33,29 @@ The explanations of the derived traits are as follows:
 \item \code{AG}: Average degree of galactosylation per antenna
 \item \code{TS}: Proportion of sialylated glycans
 }
+
+Two additional sialic acid linkage traits are included if \code{sia_link = TRUE}.
+\itemize{
+\item \code{GE}: Average degree of α2,6-linked sialylation per galactose
+\item \code{GL}: Average degree of α2,3-linked sialylation per galactose
+\item \code{TE}: Proportion of α2,6-linked sialylated glycans
+\item \code{TL}: Proportion of α2,3-linked sialylated glycans
 }
+}
+
+\section{Usage of sialic acid linkage traits}{
+To use these sialic acid linkage traits,
+\code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
+\itemize{
+\item \code{nE}: Number of α2,6-linked sialic acids
+\item \code{nL}: Number of α2,3-linked sialic acids
+}
+
+Note that you have to add these two columns even if the \code{glycan_structure} column has intact linkages.
+This is because by convention all traits work with glycan structures with "basic" structure levels
+(i.e., with generic monosaccharides like "Hex" and "HexNAc" and no linkages specified).
+}
+
 \examples{
 basic_traits()
 

--- a/man/basic_traits.Rd
+++ b/man/basic_traits.Rd
@@ -36,10 +36,10 @@ The explanations of the derived traits are as follows:
 
 Two additional sialic acid linkage traits are included if \code{sia_link = TRUE}.
 \itemize{
-\item \code{GE}: Average degree of α2,6-linked sialylation per galactose
-\item \code{GL}: Average degree of α2,3-linked sialylation per galactose
-\item \code{TE}: Proportion of α2,6-linked sialylated glycans
-\item \code{TL}: Proportion of α2,3-linked sialylated glycans
+\item \code{GE}: Average degree of a2,6-linked sialylation per galactose
+\item \code{GL}: Average degree of a2,3-linked sialylation per galactose
+\item \code{TE}: Proportion of a2,6-linked sialylated glycans
+\item \code{TL}: Proportion of a2,3-linked sialylated glycans
 }
 }
 
@@ -47,8 +47,8 @@ Two additional sialic acid linkage traits are included if \code{sia_link = TRUE}
 To use these sialic acid linkage traits,
 \code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
 \itemize{
-\item \code{nE}: Number of α2,6-linked sialic acids
-\item \code{nL}: Number of α2,3-linked sialic acids
+\item \code{nE}: Number of a2,6-linked sialic acids
+\item \code{nL}: Number of a2,3-linked sialic acids
 }
 
 Note that you have to add these two columns even if the \code{glycan_structure} column has intact linkages.

--- a/man/basic_traits.Rd
+++ b/man/basic_traits.Rd
@@ -6,6 +6,9 @@
 \usage{
 basic_traits(sia_link = FALSE)
 }
+\arguments{
+\item{sia_link}{A boolean indicating whether to include sialic acid linkage traits. Default is \code{FALSE}.}
+}
 \value{
 A named list of derived traits.
 }

--- a/tests/testthat/_snaps/glydet-traits.md
+++ b/tests/testthat/_snaps/glydet-traits.md
@@ -1,0 +1,14 @@
+# basic_traits() with sia_link = TRUE works
+
+    Code
+      traits <- basic_traits(sia_link = TRUE)
+    Message
+      i Please ensure that nE and nL are in var_info. See `?basic_traits` for details.
+
+# all_traits() with sia_link = TRUE works
+
+    Code
+      traits <- all_traits(sia_link = TRUE)
+    Message
+      i Please ensure that nE and nL are in var_info. See `?all_traits` for details.
+

--- a/tests/testthat/test-glydet-traits.R
+++ b/tests/testthat/test-glydet-traits.R
@@ -1,0 +1,23 @@
+test_that("basic_traits() works", {
+  traits <- basic_traits()
+  expect_true(is.list(traits))
+  expect_true(all(c("TM", "CA2", "TF") %in% names(traits)))
+})
+
+test_that("basic_traits() with sia_link = TRUE works", {
+  expect_snapshot(traits <- basic_traits(sia_link = TRUE))
+  expect_true(is.list(traits))
+  expect_true(all(c("TM", "CA2", "TF", "GE", "GL") %in% names(traits)))
+})
+
+test_that("all_traits() works", {
+  traits <- all_traits()
+  expect_true(is.list(traits))
+  expect_true(all(c("TM", "CA2", "TF", "A2Fc") %in% names(traits)))
+})
+
+test_that("all_traits() with sia_link = TRUE works", {
+  expect_snapshot(traits <- all_traits(sia_link = TRUE))
+  expect_true(is.list(traits))
+  expect_true(all(c("TM", "CA2", "TF", "A2Fc", "GE", "GL", "A2E", "A2L") %in% names(traits)))
+})


### PR DESCRIPTION
## Summary
- Add optional `sia_link` parameter to `basic_traits()` and `all_traits()` that includes α2,6- and α2,3-linked sialylation traits
- New basic traits: GE, GL, TE, TL (galactose-normalized and proportion-based sialic acid linkage traits)
- New advanced traits: A1E-A4E, A1L-A4L, A1GE-A4GE, A1GL-A4GL (antenna-specific linkage traits)
- Require `nE` and `nL` columns in `var_info` when `sia_link = TRUE`

## Test plan
- Tests cover both `basic_traits(sia_link = TRUE)` and `all_traits(sia_link = TRUE)` output

Closes #9 