### PR TITLE
Improve `explain_trait()` wording for common count predicates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glydet (development version)
 
+## Minor improvements and bug fixes
+
+* Improve `explain_trait()` wording for common count predicates (#19).
+
 # glydet 0.11.0
 
 ## New features

--- a/R/explain-trait.R
+++ b/R/explain-trait.R
@@ -401,9 +401,22 @@ explain_trait.glydet_wsum <- function(
     if (rlang::is_symbol(var) && rlang::as_string(var) == "nA") {
       if (rlang::is_syntactic_literal(val)) {
         antenna_count <- rlang::eval_bare(val)
+        if (antenna_count == 1) return("mono-antennary glycans")
         if (antenna_count == 2) return("bi-antennary glycans")
         if (antenna_count == 3) return("tri-antennary glycans")
         if (antenna_count == 4) return("tetra-antennary glycans")
+      }
+    }
+
+    if (rlang::is_symbol(var) && rlang::is_syntactic_literal(val)) {
+      var_name <- rlang::as_string(var)
+      val_num <- rlang::eval_bare(val)
+
+      if (var_name == "nS" && val_num %in% 1:4) {
+        return(paste0(.count_prefix(val_num), "-sialylated glycans"))
+      }
+      if (var_name == "nF" && val_num %in% 1:4) {
+        return(paste0(.count_prefix(val_num), "-fucosylated glycans"))
       }
     }
   }
@@ -420,6 +433,7 @@ explain_trait.glydet_wsum <- function(
       if (val_num == 0) {
         if (var_name == "nS") return("sialylated glycans")
         if (var_name == "nF") return("fucosylated glycans")
+        if (var_name == "nG") return("galactosylated glycans")
         if (var_name == "nFc") return("core-fucosylated glycans")
         if (var_name == "nFa") return("arm-fucosylated glycans")
       }
@@ -428,6 +442,20 @@ explain_trait.glydet_wsum <- function(
       if (var_name == "nA") {
         return(paste0("glycans with more than ", val_num, " antennae"))
       }
+    }
+  }
+
+  if (op == "<=" && length(args) == 2) {
+    var <- args[[1]]
+    val <- args[[2]]
+
+    if (
+      rlang::is_symbol(var) &&
+      rlang::as_string(var) == "nA" &&
+      rlang::is_syntactic_literal(val)
+    ) {
+      antenna_count <- rlang::eval_bare(val)
+      return(paste0("glycans with less or equal to ", antenna_count, " antennae"))
     }
   }
 
@@ -458,6 +486,23 @@ explain_trait.glydet_wsum <- function(
   }
 
   return(NULL)
+}
+
+#' Translate Small Counts to Glycan Description Prefixes
+#'
+#' @param count A count from 1 to 4.
+#'
+#' @returns A character prefix such as "mono", "bi", "tri", or "tetra".
+#' @noRd
+.count_prefix <- function(count) {
+  prefixes <- c(
+    "1" = "mono",
+    "2" = "bi",
+    "3" = "tri",
+    "4" = "tetra"
+  )
+
+  prefixes[[as.character(count)]]
 }
 
 .try_special_value_patterns <- function(expr) {

--- a/R/explain-trait.R
+++ b/R/explain-trait.R
@@ -455,7 +455,21 @@ explain_trait.glydet_wsum <- function(
       rlang::is_syntactic_literal(val)
     ) {
       antenna_count <- rlang::eval_bare(val)
-      return(paste0("glycans with less or equal to ", antenna_count, " antennae"))
+      return(paste0("glycans with at most ", antenna_count, " antennae"))
+    }
+  }
+
+  if (op == ">=" && length(args) == 2) {
+    var <- args[[1]]
+    val <- args[[2]]
+
+    if (
+      rlang::is_symbol(var) &&
+      rlang::as_string(var) == "nA" &&
+      rlang::is_syntactic_literal(val)
+    ) {
+      antenna_count <- rlang::eval_bare(val)
+      return(paste0("glycans with at least ", antenna_count, " antennae"))
     }
   }
 

--- a/tests/testthat/test-explain-trait.R
+++ b/tests/testthat/test-explain-trait.R
@@ -88,57 +88,77 @@ test_that("explain_trait works for custom proportion traits", {
   )
 })
 
-test_that("explain_trait explains common count predicates in proportion traits", {
+test_that("explain_trait explains fucosylation within mono-antennary glycans", {
   expect_equal(
     explain_trait(prop(nF > 0, within = (nA == 1))),
     "Proportion of fucosylated glycans within mono-antennary glycans."
   )
+})
 
+test_that("explain_trait explains galactosylation within complex glycans", {
   expect_equal(
     explain_trait(prop(nG > 0, within = (Tp == "complex"))),
     "Proportion of galactosylated glycans within complex glycans."
   )
+})
 
+test_that("explain_trait explains mono-sialylated glycans", {
   expect_equal(
     explain_trait(prop(nS == 1)),
     "Proportion of mono-sialylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains bi-sialylated glycans", {
   expect_equal(
     explain_trait(prop(nS == 2)),
     "Proportion of bi-sialylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains tri-sialylated glycans", {
   expect_equal(
     explain_trait(prop(nS == 3)),
     "Proportion of tri-sialylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains tetra-sialylated glycans", {
   expect_equal(
     explain_trait(prop(nS == 4)),
     "Proportion of tetra-sialylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains mono-fucosylated glycans", {
   expect_equal(
     explain_trait(prop(nF == 1)),
     "Proportion of mono-fucosylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains bi-fucosylated glycans", {
   expect_equal(
     explain_trait(prop(nF == 2)),
     "Proportion of bi-fucosylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains tri-fucosylated glycans", {
   expect_equal(
     explain_trait(prop(nF == 3)),
     "Proportion of tri-fucosylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains tetra-fucosylated glycans", {
   expect_equal(
     explain_trait(prop(nF == 4)),
     "Proportion of tetra-fucosylated glycans among all glycans."
   )
+})
 
+test_that("explain_trait explains less-or-equal antenna predicates", {
   expect_equal(
     explain_trait(prop(nA <= 2)),
     "Proportion of glycans with less or equal to 2 antennae among all glycans."

--- a/tests/testthat/test-explain-trait.R
+++ b/tests/testthat/test-explain-trait.R
@@ -158,10 +158,17 @@ test_that("explain_trait explains tetra-fucosylated glycans", {
   )
 })
 
-test_that("explain_trait explains less-or-equal antenna predicates", {
+test_that("explain_trait explains at-most antenna predicates", {
   expect_equal(
     explain_trait(prop(nA <= 2)),
-    "Proportion of glycans with less or equal to 2 antennae among all glycans."
+    "Proportion of glycans with at most 2 antennae among all glycans."
+  )
+})
+
+test_that("explain_trait explains at-least antenna predicates", {
+  expect_equal(
+    explain_trait(prop(nA >= 2)),
+    "Proportion of glycans with at least 2 antennae among all glycans."
   )
 })
 

--- a/tests/testthat/test-explain-trait.R
+++ b/tests/testthat/test-explain-trait.R
@@ -88,6 +88,63 @@ test_that("explain_trait works for custom proportion traits", {
   )
 })
 
+test_that("explain_trait explains common count predicates in proportion traits", {
+  expect_equal(
+    explain_trait(prop(nF > 0, within = (nA == 1))),
+    "Proportion of fucosylated glycans within mono-antennary glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nG > 0, within = (Tp == "complex"))),
+    "Proportion of galactosylated glycans within complex glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nS == 1)),
+    "Proportion of mono-sialylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nS == 2)),
+    "Proportion of bi-sialylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nS == 3)),
+    "Proportion of tri-sialylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nS == 4)),
+    "Proportion of tetra-sialylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nF == 1)),
+    "Proportion of mono-fucosylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nF == 2)),
+    "Proportion of bi-fucosylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nF == 3)),
+    "Proportion of tri-fucosylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nF == 4)),
+    "Proportion of tetra-fucosylated glycans among all glycans."
+  )
+
+  expect_equal(
+    explain_trait(prop(nA <= 2)),
+    "Proportion of glycans with less or equal to 2 antennae among all glycans."
+  )
+})
+
 test_that("explain_trait works for ratio traits", {
   # Simple ratio
   expect_equal(


### PR DESCRIPTION
## Summary
- Teach `explain_trait()` to describe several common `prop()` predicates in human terms instead of falling back to generic predicate text.
- Cover mono-antenary, galactosylation, sialylation, fucosylation, and `nA <= 2` phrasing.
- Add focused tests for the issue examples.

## Testing
- `devtools::document()`
- `devtools::test(filter = "explain-trait")`
- `devtools::test()`

Closes #18