### PR TITLE
Use trait column for quantify_motifs output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glydet (development version)
 
+* `quantify_motifs()` now uses a `trait` column in returned `var_info`, matching `derive_traits()`, instead of a separate `motif` column (#21).
+
 # glydet 0.11.1
 
 ## Minor improvements and bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glydet (development version)
 
-* `quantify_motifs()` now uses a `trait` column in returned `var_info`, matching `derive_traits()`, instead of a separate `motif` column (#21).
+* `quantify_motifs()` now uses a `trait` column in returned `var_info`, matching `derive_traits()`, instead of a separate `motif` column (#22).
 
 # glydet 0.11.1
 

--- a/R/quantify-motifs.R
+++ b/R/quantify-motifs.R
@@ -136,8 +136,9 @@
 #' the new experiment contains quantifications of each motif on each glycosite in each sample
 #' (for glycoproteomics data) or motif quantifications in each sample (for glycomics data).
 #'
-#' The `var_info` table includes a `motif_structure` column containing the parsed glycan structure
-#' for each motif, allowing traceability of motif definitions.
+#' The `var_info` table includes a `trait` column with motif names and a
+#' `motif_structure` column containing the parsed glycan structure for each motif,
+#' allowing traceability of motif definitions.
 #'
 #' For glycoproteomics data, with additional columns:
 #' - `protein`: protein ID
@@ -235,7 +236,7 @@ quantify_motifs <- function(
 
   # Create lookup tibble: motif names -> motif structures
   motif_lookup <- tibble::tibble(
-    motif = mp_cols,
+    trait = mp_cols,
     motif_structure = unname(motif_structures)
   )
 
@@ -250,7 +251,6 @@ quantify_motifs <- function(
   # Calculate the traits
   trait_exp <- derive_traits(exp2, trait_fns = trait_fns, mp_cols = mp_cols)
   result <- trait_exp |>
-    glyexp::rename_var(dplyr::all_of(c("motif" = "trait"))) |>
     # Remove meta-property columns (if any)
     # `derive_traits()` has a special logic of rescuing columns
     # that have "many-to-one" relationship with glycosites.
@@ -260,7 +260,7 @@ quantify_motifs <- function(
     glyexp::select_var(-all_of("explanation"))
 
   # Add motif_structure column via left_join
-  glyexp::left_join_var(result, motif_lookup, by = "motif")
+  glyexp::left_join_var(result, motif_lookup, by = "trait")
 }
 
 #' Add motif count meta-property columns

--- a/man/quantify_motifs.Rd
+++ b/man/quantify_motifs.Rd
@@ -49,8 +49,9 @@ Instead of containing quantifications of individual glycans on each glycosite in
 the new experiment contains quantifications of each motif on each glycosite in each sample
 (for glycoproteomics data) or motif quantifications in each sample (for glycomics data).
 
-The \code{var_info} table includes a \code{motif_structure} column containing the parsed glycan structure
-for each motif, allowing traceability of motif definitions.
+The \code{var_info} table includes a \code{trait} column with motif names and a
+\code{motif_structure} column containing the parsed glycan structure for each motif,
+allowing traceability of motif definitions.
 
 For glycoproteomics data, with additional columns:
 \itemize{

--- a/tests/testthat/test-quantify-motifs.R
+++ b/tests/testthat/test-quantify-motifs.R
@@ -121,7 +121,8 @@ test_that("quantify_motifs works for glycomics data absolutely", {
   colnames(expected_expr_mat) <- colnames(exp$expr_mat)
   rownames(expected_expr_mat) <- c("sia", "core")
   expect_equal(result$expr_mat, expected_expr_mat)
-  expect_equal(result$var_info$motif, c("sia", "core"))
+  expect_false("motif" %in% colnames(result$var_info))
+  expect_equal(result$var_info$trait, c("sia", "core"))
 })
 
 test_that("quantify_motifs works for glycomics data relatively", {
@@ -139,7 +140,7 @@ test_that("quantify_motifs works for glycomics data relatively", {
   colnames(expected_expr_mat) <- colnames(exp$expr_mat)
   rownames(expected_expr_mat) <- c("sia", "core")
   expect_equal(result$expr_mat, expected_expr_mat)
-  expect_equal(result$var_info$motif, c("sia", "core"))
+  expect_equal(result$var_info$trait, c("sia", "core"))
 })
 
 test_that("quantify_motifs works for glycoproteomics data absolutely", {
@@ -175,7 +176,7 @@ test_that("quantify_motifs works for glycoproteomics data absolutely", {
   )
   expect_equal(result$var_info$protein, c("P1", "P1", "P1", "P1"))
   expect_equal(result$var_info$protein_site, c(1, 1, 2, 2))
-  expect_equal(result$var_info$motif, c("sia", "core", "sia", "core"))
+  expect_equal(result$var_info$trait, c("sia", "core", "sia", "core"))
 
   # Check motif_structure column exists and has correct type
   expect_true("motif_structure" %in% colnames(result$var_info))
@@ -237,7 +238,7 @@ test_that("quantify_motifs works for glycoproteomics data relatively", {
   )
   expect_equal(result$var_info$protein, c("P1", "P1", "P1", "P1"))
   expect_equal(result$var_info$protein_site, c(1, 1, 2, 2))
-  expect_equal(result$var_info$motif, c("sia", "core", "sia", "core"))
+  expect_equal(result$var_info$trait, c("sia", "core", "sia", "core"))
 
   # Check motif_structure column exists and has correct type
   expect_true("motif_structure" %in% colnames(result$var_info))
@@ -265,7 +266,7 @@ test_that("quantify_motifs keeps additional columns for glycoproteomics data", {
   # Test
   expect_setequal(
     colnames(result$var_info),
-    c("variable", "protein", "protein_site", "motif", "motif_structure", "gene")
+    c("variable", "protein", "protein_site", "trait", "motif_structure", "gene")
   )
 })
 
@@ -335,7 +336,7 @@ test_that("quantify_motifs works with known motif names", {
 
   # Test motifs are correctly named
   expect_equal(
-    result$var_info$motif,
+    result$var_info$trait,
     c("N-Glycan core, core-fucosylated", "N-Glycan high mannose")
   )
 })
@@ -355,7 +356,7 @@ test_that("quantify_motifs works with glycan_structure vector", {
 
   # Test motifs are correctly named (using structure strings as names)
   expect_equal(
-    result$var_info$motif,
+    result$var_info$trait,
     c(
       "Neu5Ac(a2-3)Gal(b1-",
       "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
@@ -379,8 +380,8 @@ test_that("quantify_motifs works with dynamic_motifs() for glycomics data", {
   )))
 
   # Check that motif names are IUPAC strings (auto-generated)
-  expect_type(result$var_info$motif, "character")
-  expect_true(all(nchar(result$var_info$motif) > 0))
+  expect_type(result$var_info$trait, "character")
+  expect_true(all(nchar(result$var_info$trait) > 0))
 })
 
 test_that("quantify_motifs works with branch_motifs() for glycomics data", {
@@ -395,8 +396,8 @@ test_that("quantify_motifs works with branch_motifs() for glycomics data", {
   )))
 
   # Check that motif names are trimmed branch names (not full IUPAC with core)
-  expect_type(result$var_info$motif, "character")
-  expect_true(all(nchar(result$var_info$motif) > 0))
+  expect_type(result$var_info$trait, "character")
+  expect_true(all(nchar(result$var_info$trait) > 0))
 })
 
 test_that("quantify_motifs works with dynamic_motifs() for glycoproteomics data", {

--- a/vignettes/quantify-motifs.Rmd
+++ b/vignettes/quantify-motifs.Rmd
@@ -64,9 +64,8 @@ motif_exp
 get_var_info(motif_exp)
 ```
 
-Notice how the variable information now includes a `motif` column instead of the usual `trait` column.
-Don't worry—this is just a cosmetic difference.
-Under the hood, the functionality works exactly the same way as `derive_traits()`.
+Notice how the variable information includes a `trait` column, matching the output schema of `derive_traits()`.
+Under the hood, motif quantification works exactly the same way as `derive_traits()`.
 
 ## Absolute vs. relative motif quantification
 


### PR DESCRIPTION
## Summary

Update `quantify_motifs()` so the returned `var_info` uses a `trait` column instead of a separate `motif` column.

## Background

Issue #21 asks for the motif quantification output schema to match `derive_traits()`. The returned `var_info` already includes `motif_structure`, so the motif definition remains traceable without a dedicated `motif` column.

## Details

- Preserve the `trait` column produced by `derive_traits()` instead of renaming it to `motif`.
- Join `motif_structure` metadata by `trait`.
- Update regression tests for glycomics, glycoproteomics, known motif names, structure-vector motifs, and generated motif specs.
- Update the `quantify_motifs()` documentation and vignette wording.
- Add the development NEWS entry with the live PR suffix `(#22)`.

## Verification

- `Rscript -e 'suppressMessages(devtools::document())'`
- `Rscript -e 'suppressMessages(devtools::load_all()); suppressMessages(devtools::test(filter = "quantify-motifs"))'` -> `FAIL 0 | WARN 0 | SKIP 0 | PASS 63`
- `Rscript -e 'suppressMessages(devtools::load_all()); suppressMessages(devtools::test())'` -> `FAIL 0 | WARN 0 | SKIP 0 | PASS 285`
- `air format .`
- `git diff --check`
- `Rscript -e 'suppressMessages(devtools::check(error_on = "warning"))'` -> 0 errors, 0 warnings, 1 NOTE for system-clock verification in this sandboxed environment.
- After the NEWS follow-up: `git diff --check`

Closes #21