### PR TITLE
Migrate examples to Stage II glyexp containers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
-    glyexp (>= 0.15.0),
+    glyexp (>= 0.16.0),
     glyclean (>= 0.12.0),
     glystats (>= 0.6.3),
     missForest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glydet (development version)
 
-* Documentation, examples, and vignettes now use `GlycomicSE` and `GlycoproteomicSE` inputs with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15.
+* Documentation, examples, and vignettes now use `GlycomicSE` and `GlycoproteomicSE` inputs with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15. (#27)
 
 # glydet 0.12.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glydet (development version)
 
+* Documentation, examples, and vignettes now use `GlycomicSE` and `GlycoproteomicSE` inputs with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15.
+
 # glydet 0.12.1
 
 * `add_meta_properties()`, `derive_traits()`, and `quantify_motifs()` now work consistently across legacy `glyexp::experiment()` and current `SummarizedExperiment` containers.

--- a/R/derive-traits.R
+++ b/R/derive-traits.R
@@ -1,18 +1,19 @@
 #' Calculate Derived Traits
 #'
 #' @description
-#' This function calculates derived traits from a [glyexp::experiment()],
-#' [glyexp::GlycomicSE()], or [glyexp::GlycoproteomicSE()] object.
+#' This function calculates derived traits from a [glyexp::GlycomicSE()] or
+#' [glyexp::GlycoproteomicSE()] object.
 #' For glycomics data, it calculates the derived traits directly.
 #' For glycoproteomics data, each glycosite is treated as a separate glycome,
 #' and derived traits are calculated in a site-specific manner.
 #'
-#' @param exp A [glyexp::experiment()], [glyexp::GlycomicSE()], or
-#'   [glyexp::GlycoproteomicSE()] object. Before using this function,
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object.
+#'   Before using this function,
 #'   you should preprocess the data using the `glyclean` package.
 #'   For glycoproteomics data, the data should be aggregated to the
 #'   "gfs" (glycoforms with structures) level using `glyclean::aggregate()`.
-#'   Also, please make sure that the `glycan_structure` column is present in the `var_info` table,
+#'   Also, please make sure that the `glycan_structure` column is present in
+#'   [SummarizedExperiment::rowData()],
 #'   as not all glycoproteomics identification softwares provide this information.
 #'   "glycan_structure" can be a `glyrepr::glycan_structure()` vector,
 #'   or a character vector of glycan structure strings supported by `glyparse::auto_parse()`.
@@ -23,22 +24,24 @@
 #'   This parameter is useful if your trait functions use custom meta-properties
 #'   other than those in [all_mp_fns()].
 #'   Default is `NULL`, which means all meta-properties in [all_mp_fns()] are used.
-#' @param mp_cols A character vector of column names in the `var_info` tibble to use as meta-properties.
+#' @param mp_cols A character vector of column names in [SummarizedExperiment::rowData()]
+#'   to use as meta-properties.
 #'   If names are provided, they will be used as names of the meta-properties,
 #'   otherwise the column names will be used.
 #'   When `mp_cols` is specified, the selected columns overwrite meta-properties introduced by `mp_fns`
 #'   with the same names, including built-in meta-properties.
-#'   Default is `NULL`, which means all columns in `var_info` are available as meta-properties by their
-#'   existing names. In this default mode, meta-properties introduced by `mp_fns` take precedence over
-#'   `var_info` columns with the same names.
+#'   Default is `NULL`, which means all columns in `rowData()` are available as
+#'   meta-properties by their existing names. In this default mode,
+#'   meta-properties introduced by `mp_fns` take precedence over `rowData()`
+#'   columns with the same names.
 #'
 #' @returns
-#' A new [glyexp::experiment()] object for legacy `experiment()` input, or a
-#' `SummarizedExperiment` object for `GlycomicSE` or `GlycoproteomicSE` input.
+#' New `GlycomicSE` and `GlycoproteomicSE` inputs return a plain
+#' `SummarizedExperiment`; compatible legacy glyexp inputs preserve their
+#' legacy container type.
 #' Instead of "quantification of each glycan on each glycosite in each sample",
-#' the new `experiment()` contains "the value of each derived trait on each glycosite in each sample",
-#' with the following columns in the `var_info` table:
-#' - `variable`: variable ID
+#' its assay contains "the value of each derived trait on each glycosite in each
+#' sample", with the following columns in `rowData()`:
 #' - `trait`: derived trait name
 #' - `explanation`: a concise English explanation of the trait
 #'
@@ -46,7 +49,7 @@
 #' - `protein`: protein ID
 #' - `protein_site`: the glycosite position on the protein
 #'
-#' Other columns in the `var_info` table (e.g. `gene`) are retained if they have "many-to-one"
+#' Other columns in `rowData()` (e.g. `gene`) are retained if they have "many-to-one"
 #' relationship with glycosites (unique combinations of `protein`, `protein_site`).
 #' That is, each glycosite cannot have multiple values for these columns.
 #' `gene` is a common example, as a glycosite can only be associate with one gene.
@@ -56,30 +59,29 @@
 #' Don't worry if you cannot understand this logic,
 #' as long as you know that this function will try its best to preserve useful information.
 #'
-#' `sample_info` and `meta_data` are not modified,
-#'  except that the `exp_type` field of `meta_data` is set to "traitomics" for glycomics data,
-#'  and "traitproteomics" for glycoproteomics data.
+#' `colData()` and `metadata()` are not modified, except that the `exp_type`
+#' field of `metadata()` is set to "traitomics" for glycomics data and
+#' "traitproteomics" for glycoproteomics data.
 #'
 #' @examples
 #' library(glyexp)
+#' library(SummarizedExperiment)
 #' library(glyclean)
 #'
-#' exp <- real_experiment |>
-#'   auto_clean()
-#' if (inherits(exp, "glyexp_experiment")) {
-#'   exp <- slice_sample_var(exp, n = 100)
-#' } else {
-#'   exp <- slice_sample_row(exp, n = 100)
-#' }
-#' trait_exp <- derive_traits(exp)
-#' trait_exp
+#' gp_se <- real_experiment |>
+#'   auto_clean() |>
+#'   slice_sample_row(n = 100)
+#' trait_se <- derive_traits(gp_se)
+#' rowData(trait_se)
+#' assay(trait_se)[1:5, 1:5]
+#' colData(trait_se)
 #'
 #' # By default, only basic traits are calculated
 #' names(traits_basic())
 #'
 #' # You can calculate detailed traits in `traits_detailed()`
-#' more_trait_exp <- derive_traits(exp, trait_fns = traits_detailed())
-#' more_trait_exp
+#' more_trait_se <- derive_traits(gp_se, trait_fns = traits_detailed())
+#' more_trait_se
 #'
 #' @seealso [traits_basic()], [traits_detailed()]
 #'
@@ -222,7 +224,7 @@ derive_traits <- function(
 
 #' Get Meta-Properties from Experiment
 #'
-#' @param exp An [glyexp::experiment()] object.
+#' @param exp A supported glyexp data container.
 #' @param mp_fns A named list of meta-property functions.
 #' @param mp_cols A character vector of column names in the `var_info` tibble to use as meta-properties.
 #'

--- a/R/glydet-traits.R
+++ b/R/glydet-traits.R
@@ -35,7 +35,8 @@
 #' # Usage of sialic acid linkage traits
 #'
 #' To use these sialic acid linkage traits,
-#' `var_info` of the input `glyexp::experiment()` must have the following columns:
+#' `rowData()` of the input `GlycomicSE` or `GlycoproteomicSE` must have the
+#' following columns:
 #'
 #' - `nE`: Number of a2,6-linked sialic acids
 #' - `nL`: Number of a2,3-linked sialic acids

--- a/R/meta-properties.R
+++ b/R/meta-properties.R
@@ -44,17 +44,15 @@ get_meta_properties <- function(glycans, mp_fns = NULL) {
   tibble::as_tibble(purrr::map(mp_fns, ~ .x(glycans)))
 }
 
-#' Add Meta-Properties to Experiment
+#' Add Meta-Properties to a Glyco SummarizedExperiment
 #'
 #' This function adds meta-properties to the variable information of a
-#' [glyexp::experiment()], [glyexp::GlycomicSE()], or
-#' [glyexp::GlycoproteomicSE()].
+#' [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()].
 #' Under the hood, it uses [get_meta_properties()] to calculate the meta-properties
 #' on the "glycan_structure" column (or column specified by `struc_col`) of the variable information tibble,
 #' and then adds the result back as new columns.
 #'
-#' @param exp A [glyexp::experiment()], [glyexp::GlycomicSE()], or
-#'   [glyexp::GlycoproteomicSE()] object.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object.
 #' @param mp_fns A named list of meta-property functions.
 #'   Names of the list are the names of the meta-properties. Default is [all_mp_fns()].
 #'   A meta-property function should takes a `glyrepr::glycan_structure()` vector,
@@ -72,24 +70,16 @@ get_meta_properties <- function(glycans, mp_fns = NULL) {
 #' library(glyexp)
 #' library(SummarizedExperiment)
 #'
-#' # Compare the columns in the variable information before and after adding meta-properties
-#' exp <- real_experiment
-#' if (inherits(exp, "glyexp_experiment")) {
-#'   exp <- slice_sample_var(exp, n = 10)
-#'   colnames(get_var_info(exp))
-#' } else {
-#'   exp <- slice_sample_row(exp, n = 10)
-#'   colnames(rowData(exp))
-#' }
+#' # Compare rowData columns before and after adding meta-properties
+#' gp_se <- real_experiment |>
+#'   slice_sample_row(n = 10)
+#' colnames(rowData(gp_se))
 #'
-#' exp2 <- add_meta_properties(exp)
-#' if (inherits(exp2, "glyexp_experiment")) {
-#'   colnames(get_var_info(exp2))
-#' } else {
-#'   colnames(rowData(exp2))
-#' }
+#' gp_se2 <- add_meta_properties(gp_se)
+#' colnames(rowData(gp_se2))
 #'
-#' @seealso [get_meta_properties()], [glyexp::experiment()]
+#' @seealso [get_meta_properties()], [glyexp::GlycomicSE()],
+#'   [glyexp::GlycoproteomicSE()]
 #'
 #' @export
 add_meta_properties <- function(

--- a/R/quantify-motifs.R
+++ b/R/quantify-motifs.R
@@ -6,12 +6,12 @@
 #' For glycoproteomics data, each glycosite is treated as a separate glycome,
 #' and motif quantifications are calculated in a site-specific manner.
 #'
-#' The function takes a `glyexp::experiment()`, `glyexp::GlycomicSE`, or
-#' `glyexp::GlycoproteomicSE` object and returns a new data container with motif
-#' quantifications. Instead of containing quantifications of individual glycans
-#' on each glycosite in each sample, the new experiment contains quantifications
-#' of each motif on each glycosite in each sample (for glycoproteomics data) or
-#' motif quantifications in each sample (for glycomics data).
+#' The function takes a `glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE`
+#' object and returns a plain `SummarizedExperiment` with motif quantifications.
+#' Instead of containing quantifications of individual glycans on each glycosite
+#' in each sample, the output assay contains quantifications of each motif on
+#' each glycosite in each sample (for glycoproteomics data) or motif
+#' quantifications in each sample (for glycomics data).
 #'
 #' @details
 #' # Relative and Absolute Motif Quantification
@@ -132,14 +132,14 @@
 #'   See [glymotif::have_motifs()] for details.
 #'
 #' @returns
-#' A new [glyexp::experiment()] object for legacy `experiment()` input, or a
-#' `SummarizedExperiment` object for `GlycomicSE` or `GlycoproteomicSE` input,
-#' containing motif quantifications.
+#' New `GlycomicSE` and `GlycoproteomicSE` inputs return a plain
+#' `SummarizedExperiment`; compatible legacy glyexp inputs preserve their
+#' legacy container type. The output contains motif quantifications.
 #' Instead of containing quantifications of individual glycans on each glycosite in each sample,
-#' the new experiment contains quantifications of each motif on each glycosite in each sample
+#' the output assay contains quantifications of each motif on each glycosite in each sample
 #' (for glycoproteomics data) or motif quantifications in each sample (for glycomics data).
 #'
-#' The `var_info` table includes a `trait` column with motif names and a
+#' `rowData()` includes a `trait` column with motif names and a
 #' `motif_structure` column containing the parsed glycan structure for each motif,
 #' allowing traceability of motif definitions.
 #'
@@ -147,7 +147,7 @@
 #' - `protein`: protein ID
 #' - `protein_site`: the glycosite position on the protein
 #'
-#' Other columns in the `var_info` table (e.g., `gene`) are retained if they have a "many-to-one"
+#' Other columns in `rowData()` (e.g., `gene`) are retained if they have a "many-to-one"
 #' relationship with glycosites (unique combinations of `protein`, `protein_site`).
 #' That is, each glycosite cannot have multiple values for these columns.
 #' `gene` is a common example, as a glycosite can only be associated with one gene.
@@ -157,34 +157,34 @@
 #' Don't worry if you cannot understand this logic—
 #' just know that this function will do its best to preserve useful information.
 #'
-#' The `sample_info` and `meta_data` tables are not modified,
-#' except that the `exp_type` field in `meta_data` is set to "traitomics" for glycomics data
-#' and "traitproteomics" for glycoproteomics data.
+#' `colData()` and `metadata()` are not modified, except that the `exp_type`
+#' field in `metadata()` is set to "traitomics" for glycomics data and
+#' "traitproteomics" for glycoproteomics data.
 #'
 #' @examples
 #' library(glyexp)
+#' library(SummarizedExperiment)
 #' library(glyclean)
 #'
-#' exp <- real_experiment |>
-#'   auto_clean()
-#' if (inherits(exp, "glyexp_experiment")) {
-#'   exp <- slice_head_var(exp, n = 10)
-#' } else {
-#'   exp <- slice_head_row(exp, n = 10)
-#' }
+#' gp_se <- real_experiment |>
+#'   auto_clean() |>
+#'   slice_head_row(n = 10)
 #'
 #' motifs <- c(
 #'   nLx = "Hex(??-?)[dHex(??-?)]HexNAc(??-",  # Lewis x antigen
 #'   nSLx = "NeuAc(??-?)Hex(??-?)[dHex(??-?)]HexNAc(??-"  # Sialyl Lewis x antigen
 #' )
 #'
-#' quantify_motifs(exp, motifs)
+#' motif_se <- quantify_motifs(gp_se, motifs)
+#' rowData(motif_se)
+#' assay(motif_se)
+#' colData(motif_se)
 #'
 #' # Using dynamic motifs (auto-extracted from data)
-#' quantify_motifs(exp, glymotif::dynamic_motifs(max_size = 3))
+#' quantify_motifs(gp_se, glymotif::dynamic_motifs(max_size = 3))
 #'
 #' # Using branch motifs (auto-extracted from data)
-#' quantify_motifs(exp, glymotif::branch_motifs())
+#' quantify_motifs(gp_se, glymotif::branch_motifs())
 #'
 #' @seealso [derive_traits()], [glymotif::have_motifs()]
 #' @export
@@ -272,10 +272,11 @@ quantify_motifs <- function(
 
 #' Add motif count meta-property columns
 #'
-#' @param exp A [glyexp::experiment()] object.
+#' @param exp A legacy glyexp data container.
 #' @inheritParams quantify_motifs
 #'
-#' @returns A [glyexp::experiment()] object with motif count columns added to `var_info`.
+#' @returns A legacy glyexp data container with motif count columns added to its
+#'   variable information.
 #' @noRd
 .add_motif_count_mps <- function(
   exp,

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,8 +13,8 @@
 
 #' Check a glydet data container
 #'
-#' @param exp A `glyexp::experiment()`, `GlycomicSE`, or `GlycoproteomicSE`
-#'   object.
+#' @param exp A `GlycomicSE`, `GlycoproteomicSE`, or legacy glyexp data
+#'   container.
 #'
 #' @returns `NULL` invisibly, or an error if `exp` is unsupported.
 #' @noRd
@@ -64,10 +64,10 @@
 #' Restore the legacy container type
 #'
 #' @param exp A `SummarizedExperiment` object.
-#' @param legacy Whether the original input was a `glyexp::experiment()`.
+#' @param legacy Whether the original input used the legacy glyexp container.
 #'
-#' @returns `exp`, converted back to `glyexp::experiment()` when `legacy` is
-#'   `TRUE`.
+#' @returns `exp`, converted back to the legacy glyexp container when `legacy`
+#'   is `TRUE`.
 #' @noRd
 .restore_data_container <- function(exp, legacy) {
   if (legacy) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,32 +80,37 @@ First, let's load necessary packages and get the data ready.
 
 ```{r setup, message = FALSE}
 library(glyexp)
+library(SummarizedExperiment)
 library(glyclean)
 library(glydet)
 
-exp <- auto_clean(real_experiment)
+gp_se <- auto_clean(real_experiment)
 ```
 
 ```{r}
-exp
+gp_se
 ```
 
 Now, let's calculate some derived traits!
 
 ```{r}
-trait_exp <- derive_traits(exp)
-trait_exp
+trait_se <- derive_traits(gp_se)
+trait_se
 ```
 
-Voilà! What you see is a brand new `experiment()` object with "traitomics" type.
+Voilà! What you see is a plain `SummarizedExperiment` with "traitproteomics" type.
 Think of it as your original dataset's sophisticated cousin 🎭 —
 instead of tracking "quantification of each glycan on each glycosite in each sample,"
 it now contains "the value of each derived trait on each glycosite in each sample."
 
 ```{r}
-get_var_info(trait_exp)
+tibble::as_tibble(rowData(trait_se), rownames = "variable")
 ```
 
 ```{r}
-get_expr_mat(trait_exp)[1:5, 1:5]
+assay(trait_se)[1:5, 1:5]
+```
+
+```{r}
+tibble::as_tibble(colData(trait_se), rownames = "sample")
 ```

--- a/README.md
+++ b/README.md
@@ -83,64 +83,89 @@ First, let’s load necessary packages and get the data ready.
 
 ``` r
 library(glyexp)
+library(SummarizedExperiment)
 library(glyclean)
-#> Warning: 程序包'glyclean'是用R版本4.5.2 来建造的
 library(glydet)
 
-exp <- auto_clean(real_experiment)
+gp_se <- auto_clean(real_experiment)
 ```
 
 ``` r
-exp
-#> 
-#> ── Glycoproteomics Experiment ──────────────────────────────────────────────────
-#> ℹ Expression matrix: 12 samples, 3979 variables
-#> ℹ Sample information fields: group <fct>
-#> ℹ Variable information fields: protein <chr>, glycan_composition <comp>, glycan_structure <struct>, protein_site <int>, gene <chr>
+gp_se
+#>
+#> ── GlycoproteomicSE ────────────────────────────────────────────────────────────
+#> ℹ Abundance assay: 12 samples, 3979 variables
+#> ℹ Glycan type: N
+#> ℹ Row data fields: protein <chr>, glycan_composition <comp>, glycan_structure <struct>, protein_site <int>, gene <chr>
+#> ℹ Column data fields: group <fct>
+#> ℹ Metadata fields: exp_type <chr>, glycan_type <chr>, quant_method <chr>
 ```
 
 Now, let’s calculate some derived traits!
 
 ``` r
-trait_exp <- derive_traits(exp)
-trait_exp
-#> 
-#> ── Traitproteomics Experiment ──────────────────────────────────────────────────
-#> ℹ Expression matrix: 12 samples, 3864 variables
-#> ℹ Sample information fields: group <fct>
-#> ℹ Variable information fields: protein <chr>, protein_site <int>, trait <chr>, gene <chr>, explanation <chr>
+trait_se <- derive_traits(gp_se)
+trait_se
+#> class: SummarizedExperiment
+#> dim: 3864 12
+#> metadata(3): exp_type glycan_type quant_method
+#> assays(1): abundance
+#> rownames(3864): A6NJW9-49-TM A6NJW9-49-TH ... Q9Y6W6-184-AG
+#>   Q9Y6W6-184-TS
+#> rowData names(5): protein protein_site trait gene explanation
+#> colnames(12): C1 C2 ... Y2 Y3
+#> colData names(1): group
 ```
 
-Voilà! What you see is a brand new `experiment()` object with
-“traitomics” type. Think of it as your original dataset’s sophisticated
-cousin 🎭 — instead of tracking “quantification of each glycan on each
-glycosite in each sample,” it now contains “the value of each derived
-trait on each glycosite in each sample.”
+Voilà! What you see is a plain `SummarizedExperiment` with
+“traitproteomics” type. Think of it as your original dataset’s
+sophisticated cousin 🎭 — instead of tracking “quantification of each
+glycan on each glycosite in each sample,” it now contains “the value of
+each derived trait on each glycosite in each sample.”
 
 ``` r
-get_var_info(trait_exp)
+tibble::as_tibble(rowData(trait_se), rownames = "variable")
 #> # A tibble: 3,864 × 6
-#>    variable protein protein_site trait gene  explanation                        
-#>    <chr>    <chr>          <int> <chr> <chr> <chr>                              
-#>  1 V1       A6NJW9            49 TM    CD8B2 Proportion of high-mannose glycans…
-#>  2 V2       A6NJW9            49 TH    CD8B2 Proportion of hybrid glycans among…
-#>  3 V3       A6NJW9            49 TC    CD8B2 Proportion of complex glycans amon…
-#>  4 V4       A6NJW9            49 MM    CD8B2 Abundance-weighted mean of mannose…
-#>  5 V5       A6NJW9            49 CA2   CD8B2 Proportion of bi-antennary glycans…
-#>  6 V6       A6NJW9            49 CA3   CD8B2 Proportion of tri-antennary glycan…
-#>  7 V7       A6NJW9            49 CA4   CD8B2 Proportion of tetra-antennary glyc…
-#>  8 V8       A6NJW9            49 TF    CD8B2 Proportion of fucosylated glycans …
-#>  9 V9       A6NJW9            49 TFc   CD8B2 Proportion of core-fucosylated gly…
-#> 10 V10      A6NJW9            49 TFa   CD8B2 Proportion of arm-fucosylated glyc…
+#>    variable      protein protein_site trait gene  explanation
+#>    <chr>         <chr>          <int> <chr> <chr> <chr>
+#>  1 A6NJW9-49-TM  A6NJW9            49 TM    CD8B2 Proportion of high-mannose gl…
+#>  2 A6NJW9-49-TH  A6NJW9            49 TH    CD8B2 Proportion of hybrid glycans …
+#>  3 A6NJW9-49-TC  A6NJW9            49 TC    CD8B2 Proportion of complex glycans…
+#>  4 A6NJW9-49-MM  A6NJW9            49 MM    CD8B2 Abundance-weighted mean of ma…
+#>  5 A6NJW9-49-CA2 A6NJW9            49 CA2   CD8B2 Proportion of bi-antennary gl…
+#>  6 A6NJW9-49-CA3 A6NJW9            49 CA3   CD8B2 Proportion of tri-antennary g…
+#>  7 A6NJW9-49-CA4 A6NJW9            49 CA4   CD8B2 Proportion of tetra-antennary…
+#>  8 A6NJW9-49-TF  A6NJW9            49 TF    CD8B2 Proportion of fucosylated gly…
+#>  9 A6NJW9-49-TFc A6NJW9            49 TFc   CD8B2 Proportion of core-fucosylate…
+#> 10 A6NJW9-49-TFa A6NJW9            49 TFa   CD8B2 Proportion of arm-fucosylated…
 #> # ℹ 3,854 more rows
 ```
 
 ``` r
-get_expr_mat(trait_exp)[1:5, 1:5]
-#>    C1 C2 C3 H1 H2
-#> V1  0  0  0  0  0
-#> V2  0  0  0  0  0
-#> V3  1  1  1  1  1
-#> V4 NA NA NA NA NA
-#> V5  1  1  1  1  1
+assay(trait_se)[1:5, 1:5]
+#>               C1 C2 C3 H1 H2
+#> A6NJW9-49-TM   0  0  0  0  0
+#> A6NJW9-49-TH   0  0  0  0  0
+#> A6NJW9-49-TC   1  1  1  1  1
+#> A6NJW9-49-MM  NA NA NA NA NA
+#> A6NJW9-49-CA2  1  1  1  1  1
+```
+
+``` r
+tibble::as_tibble(colData(trait_se), rownames = "sample")
+#> # A tibble: 12 × 2
+#>    sample group
+#>    <chr>  <fct>
+#>  1 C1     C
+#>  2 C2     C
+#>  3 C3     C
+#>  4 H1     H
+#>  5 H2     H
+#>  6 H3     H
+#>  7 M1     M
+#>  8 M2     M
+#>  9 M3     M
+#> 10 Y1     Y
+#> 11 Y2     Y
+#> 12 Y3     Y
 ```

--- a/man/add_meta_properties.Rd
+++ b/man/add_meta_properties.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/meta-properties.R
 \name{add_meta_properties}
 \alias{add_meta_properties}
-\title{Add Meta-Properties to Experiment}
+\title{Add Meta-Properties to a Glyco SummarizedExperiment}
 \usage{
 add_meta_properties(
   exp,
@@ -12,8 +12,7 @@ add_meta_properties(
 )
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, or
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.}
 
 \item{mp_fns}{A named list of meta-property functions.
 Names of the list are the names of the meta-properties. Default is \code{\link[=all_mp_fns]{all_mp_fns()}}.
@@ -33,8 +32,7 @@ information. The input container type is preserved.
 }
 \description{
 This function adds meta-properties to the variable information of a
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, or
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}.
+\code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}.
 Under the hood, it uses \code{\link[=get_meta_properties]{get_meta_properties()}} to calculate the meta-properties
 on the "glycan_structure" column (or column specified by \code{struc_col}) of the variable information tibble,
 and then adds the result back as new columns.
@@ -43,24 +41,16 @@ and then adds the result back as new columns.
 library(glyexp)
 library(SummarizedExperiment)
 
-# Compare the columns in the variable information before and after adding meta-properties
-exp <- real_experiment
-if (inherits(exp, "glyexp_experiment")) {
-  exp <- slice_sample_var(exp, n = 10)
-  colnames(get_var_info(exp))
-} else {
-  exp <- slice_sample_row(exp, n = 10)
-  colnames(rowData(exp))
-}
+# Compare rowData columns before and after adding meta-properties
+gp_se <- real_experiment |>
+  slice_sample_row(n = 10)
+colnames(rowData(gp_se))
 
-exp2 <- add_meta_properties(exp)
-if (inherits(exp2, "glyexp_experiment")) {
-  colnames(get_var_info(exp2))
-} else {
-  colnames(rowData(exp2))
-}
+gp_se2 <- add_meta_properties(gp_se)
+colnames(rowData(gp_se2))
 
 }
 \seealso{
-\code{\link[=get_meta_properties]{get_meta_properties()}}, \code{\link[glyexp:experiment]{glyexp::experiment()}}
+\code{\link[=get_meta_properties]{get_meta_properties()}}, \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}},
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}
 }

--- a/man/derive_traits.Rd
+++ b/man/derive_traits.Rd
@@ -7,12 +7,13 @@
 derive_traits(exp, trait_fns = NULL, mp_fns = NULL, mp_cols = NULL)
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, or
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object. Before using this function,
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
+Before using this function,
 you should preprocess the data using the \code{glyclean} package.
 For glycoproteomics data, the data should be aggregated to the
 "gfs" (glycoforms with structures) level using \code{glyclean::aggregate()}.
-Also, please make sure that the \code{glycan_structure} column is present in the \code{var_info} table,
+Also, please make sure that the \code{glycan_structure} column is present in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}},
 as not all glycoproteomics identification softwares provide this information.
 "glycan_structure" can be a \code{glyrepr::glycan_structure()} vector,
 or a character vector of glycan structure strings supported by \code{glyparse::auto_parse()}.}
@@ -26,23 +27,25 @@ This parameter is useful if your trait functions use custom meta-properties
 other than those in \code{\link[=all_mp_fns]{all_mp_fns()}}.
 Default is \code{NULL}, which means all meta-properties in \code{\link[=all_mp_fns]{all_mp_fns()}} are used.}
 
-\item{mp_cols}{A character vector of column names in the \code{var_info} tibble to use as meta-properties.
+\item{mp_cols}{A character vector of column names in \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}}
+to use as meta-properties.
 If names are provided, they will be used as names of the meta-properties,
 otherwise the column names will be used.
 When \code{mp_cols} is specified, the selected columns overwrite meta-properties introduced by \code{mp_fns}
 with the same names, including built-in meta-properties.
-Default is \code{NULL}, which means all columns in \code{var_info} are available as meta-properties by their
-existing names. In this default mode, meta-properties introduced by \code{mp_fns} take precedence over
-\code{var_info} columns with the same names.}
+Default is \code{NULL}, which means all columns in \code{rowData()} are available as
+meta-properties by their existing names. In this default mode,
+meta-properties introduced by \code{mp_fns} take precedence over \code{rowData()}
+columns with the same names.}
 }
 \value{
-A new \code{\link[glyexp:experiment]{glyexp::experiment()}} object for legacy \code{experiment()} input, or a
-\code{SummarizedExperiment} object for \code{GlycomicSE} or \code{GlycoproteomicSE} input.
+New \code{GlycomicSE} and \code{GlycoproteomicSE} inputs return a plain
+\code{SummarizedExperiment}; compatible legacy glyexp inputs preserve their
+legacy container type.
 Instead of "quantification of each glycan on each glycosite in each sample",
-the new \code{experiment()} contains "the value of each derived trait on each glycosite in each sample",
-with the following columns in the \code{var_info} table:
+its assay contains "the value of each derived trait on each glycosite in each
+sample", with the following columns in \code{rowData()}:
 \itemize{
-\item \code{variable}: variable ID
 \item \code{trait}: derived trait name
 \item \code{explanation}: a concise English explanation of the trait
 }
@@ -53,7 +56,7 @@ For glycoproteomics data, with additional columns:
 \item \code{protein_site}: the glycosite position on the protein
 }
 
-Other columns in the \code{var_info} table (e.g. \code{gene}) are retained if they have "many-to-one"
+Other columns in \code{rowData()} (e.g. \code{gene}) are retained if they have "many-to-one"
 relationship with glycosites (unique combinations of \code{protein}, \code{protein_site}).
 That is, each glycosite cannot have multiple values for these columns.
 \code{gene} is a common example, as a glycosite can only be associate with one gene.
@@ -63,37 +66,36 @@ Columns not having this relationship with glycosites will be dropped.
 Don't worry if you cannot understand this logic,
 as long as you know that this function will try its best to preserve useful information.
 
-\code{sample_info} and \code{meta_data} are not modified,
-except that the \code{exp_type} field of \code{meta_data} is set to "traitomics" for glycomics data,
-and "traitproteomics" for glycoproteomics data.
+\code{colData()} and \code{metadata()} are not modified, except that the \code{exp_type}
+field of \code{metadata()} is set to "traitomics" for glycomics data and
+"traitproteomics" for glycoproteomics data.
 }
 \description{
-This function calculates derived traits from a \code{\link[glyexp:experiment]{glyexp::experiment()}},
-\code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
+This function calculates derived traits from a \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 For glycomics data, it calculates the derived traits directly.
 For glycoproteomics data, each glycosite is treated as a separate glycome,
 and derived traits are calculated in a site-specific manner.
 }
 \examples{
 library(glyexp)
+library(SummarizedExperiment)
 library(glyclean)
 
-exp <- real_experiment |>
-  auto_clean()
-if (inherits(exp, "glyexp_experiment")) {
-  exp <- slice_sample_var(exp, n = 100)
-} else {
-  exp <- slice_sample_row(exp, n = 100)
-}
-trait_exp <- derive_traits(exp)
-trait_exp
+gp_se <- real_experiment |>
+  auto_clean() |>
+  slice_sample_row(n = 100)
+trait_se <- derive_traits(gp_se)
+rowData(trait_se)
+assay(trait_se)[1:5, 1:5]
+colData(trait_se)
 
 # By default, only basic traits are calculated
 names(traits_basic())
 
 # You can calculate detailed traits in `traits_detailed()`
-more_trait_exp <- derive_traits(exp, trait_fns = traits_detailed())
-more_trait_exp
+more_trait_se <- derive_traits(gp_se, trait_fns = traits_detailed())
+more_trait_se
 
 }
 \seealso{

--- a/man/quantify_motifs.Rd
+++ b/man/quantify_motifs.Rd
@@ -13,12 +13,13 @@ quantify_motifs(
 )
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, or
-\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object. Before using this function,
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
+Before using this function,
 you should preprocess the data using the \code{glyclean} package.
 For glycoproteomics data, the data should be aggregated to the
 "gfs" (glycoforms with structures) level using \code{glyclean::aggregate()}.
-Also, please make sure that the \code{glycan_structure} column is present in the \code{var_info} table,
+Also, please make sure that the \code{glycan_structure} column is present in
+\code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment::rowData()}},
 as not all glycoproteomics identification softwares provide this information.
 "glycan_structure" can be a \code{glyrepr::glycan_structure()} vector,
 or a character vector of glycan structure strings supported by \code{glyparse::auto_parse()}.}
@@ -45,14 +46,14 @@ See \code{\link[glymotif:have_motif]{glymotif::have_motifs()}} for details.}
 See \code{\link[glymotif:have_motif]{glymotif::have_motifs()}} for details.}
 }
 \value{
-A new \code{\link[glyexp:experiment]{glyexp::experiment()}} object for legacy \code{experiment()} input, or a
-\code{SummarizedExperiment} object for \code{GlycomicSE} or \code{GlycoproteomicSE} input,
-containing motif quantifications.
+New \code{GlycomicSE} and \code{GlycoproteomicSE} inputs return a plain
+\code{SummarizedExperiment}; compatible legacy glyexp inputs preserve their
+legacy container type. The output contains motif quantifications.
 Instead of containing quantifications of individual glycans on each glycosite in each sample,
-the new experiment contains quantifications of each motif on each glycosite in each sample
+the output assay contains quantifications of each motif on each glycosite in each sample
 (for glycoproteomics data) or motif quantifications in each sample (for glycomics data).
 
-The \code{var_info} table includes a \code{trait} column with motif names and a
+\code{rowData()} includes a \code{trait} column with motif names and a
 \code{motif_structure} column containing the parsed glycan structure for each motif,
 allowing traceability of motif definitions.
 
@@ -62,7 +63,7 @@ For glycoproteomics data, with additional columns:
 \item \code{protein_site}: the glycosite position on the protein
 }
 
-Other columns in the \code{var_info} table (e.g., \code{gene}) are retained if they have a "many-to-one"
+Other columns in \code{rowData()} (e.g., \code{gene}) are retained if they have a "many-to-one"
 relationship with glycosites (unique combinations of \code{protein}, \code{protein_site}).
 That is, each glycosite cannot have multiple values for these columns.
 \code{gene} is a common example, as a glycosite can only be associated with one gene.
@@ -72,9 +73,9 @@ Columns that do not have this relationship with glycosites will be dropped.
 Don't worry if you cannot understand this logic—
 just know that this function will do its best to preserve useful information.
 
-The \code{sample_info} and \code{meta_data} tables are not modified,
-except that the \code{exp_type} field in \code{meta_data} is set to "traitomics" for glycomics data
-and "traitproteomics" for glycoproteomics data.
+\code{colData()} and \code{metadata()} are not modified, except that the \code{exp_type}
+field in \code{metadata()} is set to "traitomics" for glycomics data and
+"traitproteomics" for glycoproteomics data.
 }
 \description{
 This function quantifies motifs from glycomic or glycoproteomic profiles.
@@ -82,12 +83,12 @@ For glycomics data, it calculates motif quantifications directly.
 For glycoproteomics data, each glycosite is treated as a separate glycome,
 and motif quantifications are calculated in a site-specific manner.
 
-The function takes a \code{glyexp::experiment()}, \code{glyexp::GlycomicSE}, or
-\code{glyexp::GlycoproteomicSE} object and returns a new data container with motif
-quantifications. Instead of containing quantifications of individual glycans
-on each glycosite in each sample, the new experiment contains quantifications
-of each motif on each glycosite in each sample (for glycoproteomics data) or
-motif quantifications in each sample (for glycomics data).
+The function takes a \code{glyexp::GlycomicSE} or \code{glyexp::GlycoproteomicSE}
+object and returns a plain \code{SummarizedExperiment} with motif quantifications.
+Instead of containing quantifications of individual glycans on each glycosite
+in each sample, the output assay contains quantifications of each motif on
+each glycosite in each sample (for glycoproteomics data) or motif
+quantifications in each sample (for glycomics data).
 }
 \section{Relative and Absolute Motif Quantification}{
 Motif quantification can be performed in two ways: absolute and relative.
@@ -191,28 +192,28 @@ and everything else remains the same.
 
 \examples{
 library(glyexp)
+library(SummarizedExperiment)
 library(glyclean)
 
-exp <- real_experiment |>
-  auto_clean()
-if (inherits(exp, "glyexp_experiment")) {
-  exp <- slice_head_var(exp, n = 10)
-} else {
-  exp <- slice_head_row(exp, n = 10)
-}
+gp_se <- real_experiment |>
+  auto_clean() |>
+  slice_head_row(n = 10)
 
 motifs <- c(
   nLx = "Hex(??-?)[dHex(??-?)]HexNAc(??-",  # Lewis x antigen
   nSLx = "NeuAc(??-?)Hex(??-?)[dHex(??-?)]HexNAc(??-"  # Sialyl Lewis x antigen
 )
 
-quantify_motifs(exp, motifs)
+motif_se <- quantify_motifs(gp_se, motifs)
+rowData(motif_se)
+assay(motif_se)
+colData(motif_se)
 
 # Using dynamic motifs (auto-extracted from data)
-quantify_motifs(exp, glymotif::dynamic_motifs(max_size = 3))
+quantify_motifs(gp_se, glymotif::dynamic_motifs(max_size = 3))
 
 # Using branch motifs (auto-extracted from data)
-quantify_motifs(exp, glymotif::branch_motifs())
+quantify_motifs(gp_se, glymotif::branch_motifs())
 
 }
 \seealso{

--- a/man/traits_basic.Rd
+++ b/man/traits_basic.Rd
@@ -51,7 +51,8 @@ Four additional sialic acid linkage traits are included if \code{sia_link = TRUE
 
 \section{Usage of sialic acid linkage traits}{
 To use these sialic acid linkage traits,
-\code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
+\code{rowData()} of the input \code{GlycomicSE} or \code{GlycoproteomicSE} must have the
+following columns:
 \itemize{
 \item \code{nE}: Number of a2,6-linked sialic acids
 \item \code{nL}: Number of a2,3-linked sialic acids

--- a/man/traits_clerc_2018.Rd
+++ b/man/traits_clerc_2018.Rd
@@ -20,7 +20,8 @@ We include this function because this paper is very influential in the field.
 }
 \section{Usage of sialic acid linkage traits}{
 To use these sialic acid linkage traits,
-\code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
+\code{rowData()} of the input \code{GlycomicSE} or \code{GlycoproteomicSE} must have the
+following columns:
 \itemize{
 \item \code{nE}: Number of a2,6-linked sialic acids
 \item \code{nL}: Number of a2,3-linked sialic acids

--- a/man/traits_detailed.Rd
+++ b/man/traits_detailed.Rd
@@ -95,7 +95,8 @@ These additional sialic acid linkage traits are included if \code{sia_link = TRU
 }
 \section{Usage of sialic acid linkage traits}{
 To use these sialic acid linkage traits,
-\code{var_info} of the input \code{glyexp::experiment()} must have the following columns:
+\code{rowData()} of the input \code{GlycomicSE} or \code{GlycoproteomicSE} must have the
+following columns:
 \itemize{
 \item \code{nE}: Number of a2,6-linked sialic acids
 \item \code{nL}: Number of a2,3-linked sialic acids

--- a/vignettes/custom-traits.Rmd
+++ b/vignettes/custom-traits.Rmd
@@ -35,14 +35,6 @@ library(glyclean)
 library(glyrepr)
 
 exp <- auto_clean(real_experiment)
-
-row_info <- function(x) {
-  if (inherits(x, "glyexp_experiment")) {
-    get_var_info(x)
-  } else {
-    tibble::as_tibble(rowData(x), rownames = "variable")
-  }
-}
 ```
 
 ## Custom Traits
@@ -549,23 +541,15 @@ not directly in the glycan structures.
 
 ```{r}
 # Here we assume all sialic acids are a2-6
-if (inherits(exp, "glyexp_experiment")) {
-  exp2 <- exp |>
-    mutate_var(
-      n_a26_sia = count_mono(glycan_structure, "NeuAc"),
-      n_a23_sia = 0L
-    )
-} else {
-  exp2 <- exp |>
-    mutate_row(
-      n_a26_sia = count_mono(glycan_structure, "NeuAc"),
-      n_a23_sia = 0L
-    )
-}
+exp2 <- exp |>
+  mutate_row(
+    n_a26_sia = count_mono(glycan_structure, "NeuAc"),
+    n_a23_sia = 0L
+  )
 ```
 
 ```{r}
-row_info(exp2) |>
+tibble::as_tibble(rowData(exp2), rownames = "variable") |>
   filter(n_a26_sia > 0) |>
   pull(glycan_structure)
 ```
@@ -589,19 +573,19 @@ If the column names match the meta-property names used in the trait definitions,
 
 ```{r}
 exp3 <- exp2 |>
-  rename_var(nE = n_a26_sia, nL = n_a23_sia)
+  rename_row(nE = n_a26_sia, nL = n_a23_sia)
 
 derive_traits(exp3, trait_fns = sia_traits)
 ```
 
-If you want to use different column names in `var_info`,
+If you want to use different column names in `rowData()`,
 use `mp_cols` to map those columns to the meta-property names in the trait definitions:
 
 ```{r}
 derive_traits(exp2, trait_fns = sia_traits, mp_cols = c(nL = "n_a23_sia", nE = "n_a26_sia"))
 ```
 
-When `mp_cols` is omitted, built-in meta-properties take precedence over `var_info` columns
+When `mp_cols` is omitted, built-in meta-properties take precedence over `rowData()` columns
 with the same names. Use `mp_cols` only when you intentionally want selected columns to
 rename or overwrite meta-properties.
 

--- a/vignettes/glydet.Rmd
+++ b/vignettes/glydet.Rmd
@@ -57,72 +57,51 @@ library(SummarizedExperiment)
 library(glyclean)
 library(glystats)
 library(dplyr)
-
-row_info <- function(x) {
-  if (inherits(x, "glyexp_experiment")) {
-    get_var_info(x)
-  } else {
-    tibble::as_tibble(rowData(x), rownames = "variable")
-  }
-}
-col_info <- function(x) {
-  if (inherits(x, "glyexp_experiment")) {
-    get_sample_info(x)
-  } else {
-    tibble::as_tibble(colData(x), rownames = "sample")
-  }
-}
-abundance <- function(x) {
-  if (inherits(x, "glyexp_experiment")) {
-    get_expr_mat(x)
-  } else {
-    assay(x)
-  }
-}
 ```
 
-We'll work with `glyexp::real_experiment2`, a real glycomics dataset containing 144 samples and 67 glycans.
+We'll work with `glyexp::real_experiment2`, a real `GlycomicSE` dataset
+containing 144 samples and 67 glycans.
 
 Before calculating derived traits, preprocess your data with `glyclean`.
 This makes the trait analysis use the cleaned abundance data.
 
 ```{r}
-exp <- auto_clean(real_experiment2)  # Preprocess the data
-exp
+glyco_se <- auto_clean(real_experiment2)  # Preprocess the data
+glyco_se
 ```
 
 Let's inspect the dataset before calculating traits:
 
 ```{r}
-row_info(exp)
+tibble::as_tibble(rowData(glyco_se), rownames = "variable")
 ```
 
 ```{r}
-col_info(exp)
+tibble::as_tibble(colData(glyco_se), rownames = "sample")
 ```
 
 ```{r}
-abundance(exp)[1:5, 1:5]
+assay(glyco_se)[1:5, 1:5]
 ```
 
 Now let's calculate derived traits:
 
 ```{r}
-trait_exp <- derive_traits(exp)
-trait_exp
+trait_se <- derive_traits(glyco_se)
+trait_se
 ```
 
-The result is a new `experiment()` object with "traitomics" type.
+The result is a plain `SummarizedExperiment` with "traitomics" type.
 Instead of storing the abundance of each glycan in each sample,
 it stores the value of each derived trait in each sample.
 
 ```{r}
-row_info(trait_exp)
+tibble::as_tibble(rowData(trait_se), rownames = "variable")
 ```
 
 ```{r}
 # These are the trait values
-abundance(trait_exp)[1:5, 1:5]
+assay(trait_se)[1:5, 1:5]
 ```
 
 `derive_traits()` calculated the following built-in derived traits:
@@ -149,11 +128,11 @@ to learn how to define your own derived traits.
 For glycan classes with simpler structural patterns than N-glycans, such as O-glycans,
 we recommend using [motif quantification](https://glycoverse.github.io/glydet/articles/quantify-motifs.html) instead.
 
-Because `derive_traits()` returns a `glyexp::experiment()` object,
+Because `derive_traits()` returns a `SummarizedExperiment`,
 functions in `glystats` can be applied to the derived traits to perform statistical analyses.
 
 ```{r}
-anova_res <- gly_anova(trait_exp)
+anova_res <- gly_anova(trait_se)
 anova_res |>
   get_tidy_result("main_test") |>
   filter(p_adj < 0.05)
@@ -176,26 +155,27 @@ This captures site-specific glycosylation patterns and their variations across s
 Operationally, there is no difference between calculating derived traits for glycomics and glycoproteomics data.
 
 ```{r}
-# A glycoproteomics dataset
-gp_exp <- auto_clean(glyexp::real_experiment)
-gp_exp
+# A GlycoproteomicSE dataset
+gp_se <- auto_clean(glyexp::real_experiment)
+gp_se
 ```
 
 ```{r}
-gp_trait_exp <- derive_traits(gp_exp)
-gp_trait_exp
+gp_trait_se <- derive_traits(gp_se)
+gp_trait_se
 ```
 
-The result is also a `glyexp::experiment()` object but with "traitproteomics" type.
-The only difference is that the variable information now contains a `glycosite` column,
+The result is also a plain `SummarizedExperiment`, now with "traitproteomics" type.
+The only difference is that `rowData()` now contains a `protein_site` column,
 which indicates the glycosite for each trait variable.
-The experiment object therefore contains the value of each derived trait for each glycosite in each sample.
+The result therefore contains the value of each derived trait for each glycosite
+in each sample.
 
 You can again apply `glystats` functions to perform statistical analyses.
 For example, we can identify glycosites with dysregulated core fucosylation:
 
 ```{r}
-gly_anova(gp_trait_exp) |>
+gly_anova(gp_trait_se) |>
   get_tidy_result("main_test") |>
   filter(trait == "TFc", p_adj < 0.05) |>
   select(protein, protein_site)
@@ -222,14 +202,15 @@ then uses this information to compute the derived traits you see.
 You can also work with meta-properties directly through two functions:
 
 - **`get_meta_properties()`**: Calculate meta-properties for any set of glycans
-- **`add_meta_properties()`**: Add meta-properties to the variable information of an `experiment()` object
+- **`add_meta_properties()`**: Add meta-properties to the `rowData()` of a
+  `GlycomicSE` or `GlycoproteomicSE` object
 
 ### get_meta_properties()
 
 Let's try `get_meta_properties()` with a few glycan structures from the dataset:
 
 ```{r}
-glycans <- unique(row_info(exp)$glycan_structure)[1:5]
+glycans <- unique(rowData(glyco_se)$glycan_structure)[1:5]
 glycans
 ```
 
@@ -244,12 +225,12 @@ get_meta_properties(glycans)
 
 ### add_meta_properties()
 
-When working with `glyexp::experiment()` objects,
-you can add meta-properties directly to the variable information:
+When working with `GlycomicSE` or `GlycoproteomicSE` objects,
+you can add meta-properties directly to `rowData()`:
 
 ```{r}
-exp_with_mp <- add_meta_properties(exp)
-row_info(exp_with_mp)
+se_with_mp <- add_meta_properties(glyco_se)
+tibble::as_tibble(rowData(se_with_mp), rownames = "variable")
 ```
 
 The variable information now contains multiple meta-property columns.
@@ -258,11 +239,7 @@ This supports filtering based on structural features.
 For instance, filter for all glycoforms containing high-mannose glycans:
 
 ```{r}
-if (inherits(exp_with_mp, "glyexp_experiment")) {
-  filter_var(exp_with_mp, Tp == "highmannose")
-} else {
-  filter_row(exp_with_mp, Tp == "highmannose")
-}
+filter_row(se_with_mp, Tp == "highmannose")
 ```
 
 ### Meta-Property Functions

--- a/vignettes/quantify-motifs.Rmd
+++ b/vignettes/quantify-motifs.Rmd
@@ -24,15 +24,7 @@ library(glyexp)
 library(SummarizedExperiment)
 library(glyclean)
 
-exp <- auto_clean(real_experiment)
-
-row_info <- function(x) {
-  if (inherits(x, "glyexp_experiment")) {
-    get_var_info(x)
-  } else {
-    tibble::as_tibble(rowData(x), rownames = "variable")
-  }
-}
+gp_se <- auto_clean(real_experiment)
 ```
 
 ## What is motif quantification?
@@ -51,8 +43,9 @@ Our solution elegantly combines both pieces of information to estimate the true 
 ## The `quantify_motifs()` function
 
 Glydet provides the `quantify_motifs()` function to handle this complex task seamlessly.
-This function takes a `glyexp::experiment()` object along with your motifs of interest
-and returns a new experiment object enriched with motif quantifications.
+This function takes a `GlycomicSE` or `GlycoproteomicSE` object along with your
+motifs of interest and returns a plain `SummarizedExperiment` containing motif
+quantifications.
 Just like `derive_traits()`, `quantify_motifs()` works beautifully with both glycomics and glycoproteomics data.
 
 Let's dive into a practical example:
@@ -65,12 +58,12 @@ motifs <- c(
 )
 
 # Quantify the motifs in our dataset
-motif_exp <- quantify_motifs(exp, motifs)
-motif_exp
+motif_se <- quantify_motifs(gp_se, motifs)
+motif_se
 ```
 
 ```{r}
-row_info(motif_exp)
+tibble::as_tibble(rowData(motif_se), rownames = "variable")
 ```
 
 Notice how the variable information includes a `trait` column, matching the output schema of `derive_traits()`.
@@ -162,30 +155,23 @@ motifs <- c(
   nLxa = "Hex(??-?)[dHex(??-?)]HexNAc(??-",  # Lewis x/a antigen
   nSLxa = "NeuAc(??-?)Hex(??-?)[dHex(??-?)]HexNAc(??-"  # Sialyl Lewis x/a antigen
 )
-if (inherits(exp, "glyexp_experiment")) {
-  exp_with_mps <- exp |>
-    mutate_var(
-      tibble::as_tibble(glymotif::count_motifs(glycan_structure, motifs))
-    )
-} else {
-  exp_with_mps <- exp |>
-    mutate_row(
-      tibble::as_tibble(glymotif::count_motifs(glycan_structure, motifs))
-    )
-}
+se_with_mps <- gp_se |>
+  mutate_row(
+    tibble::as_tibble(glymotif::count_motifs(glycan_structure, motifs))
+  )
 
 # Define the traits using wsum() for absolute quantification
 trait_fns <- list(Lxa = wsum(nLxa), SLxa = wsum(nSLxa))
 
 # Calculate the traits
-derive_traits(exp_with_mps, trait_fns = trait_fns)
+derive_traits(se_with_mps, trait_fns = trait_fns)
 ```
 
 This code snippet is functionally equivalent to:
 
 ```r
 # The much simpler approach using quantify_motifs()
-quantify_motifs(exp, motifs, method = "absolute")
+quantify_motifs(gp_se, motifs, method = "absolute")
 ```
 
 Pretty neat, right?


### PR DESCRIPTION
Part of glycoverse/glyexp#15.

## Summary
- Migrate documentation, README examples, and vignettes to `GlycomicSE` and `GlycoproteomicSE` inputs.
- Use `SummarizedExperiment` accessors for plain trait and motif result containers while documenting preservation of legacy input return types.
- Require `glyexp >= 0.16.0`.

## Verification
- `devtools::check()` — 0 errors, 0 warnings, 0 notes.
- Verified no standalone legacy `experiment()` constructor calls remain in public documentation.